### PR TITLE
Add Client ID to config.json.example

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@ passport.deserializeUser(function(obj, done) {
 var scopes = ['identify'];
 
 passport.use(new DiscordStrategy({
-    clientID: "684886188603080716",
+    clientID: config.clientID,
     clientSecret: config.clientSecret,
     callbackURL: config.callbackURL
 }, function(accessToken, refreshToken, profile, done) {

--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,5 @@
 {
+	"clientID": "684886188603080716",
     "clientSecret": "kPFRYvJhoVX7mSC7byGHZ5uHnwfgufej",
     "callbackURL": "http://localhost:3000/callback"
 }


### PR DESCRIPTION
This allows for easier client ID configuration for local testing.