### PR TITLE
Add client ID to config and add npm start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tag generation for RC24
 
 ## Usage
 
-Run `npm install` then `npm test`
+Run `npm install` to install the dependencies, then run `npm start` to start the server or `npm test` to test srs/index.js syntax.
 
 ## Credits
 

--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@ passport.deserializeUser(function(obj, done) {
 var scopes = ['identify'];
 
 passport.use(new DiscordStrategy({
-    clientID: "684886188603080716",
+    clientID: config.clientID,
     clientSecret: config.clientSecret,
     callbackURL: config.callbackURL
 }, function(accessToken, refreshToken, profile, done) {

--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,5 @@
 {
+	"clientID": "684886188603080716",
     "clientSecret": "kPFRYvJhoVX7mSC7byGHZ5uHnwfgufej",
     "callbackURL": "http://localhost:3000/callback"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Tag generation for RC24",
   "main": "src/index.js",
   "scripts": {
-    "test": "node src/index.js"
+    "test": "node src/index.js",
+    "start": "node app.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Accidentally included changes of my previous PR as well, so here's an overview:
- Moves the hardcoded client ID in app.js to the config file
- Adds the `npm start` command
- Documents the above command.