### PR TITLE
Add JSON API + other minor improvements

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@ passport.deserializeUser(function(obj, done) {
 var scopes = ['identify'];
 
 passport.use(new DiscordStrategy({
-    clientID: "737308231986315348",
+    clientID: "684886188603080716",
     clientSecret: config.clientSecret,
     callbackURL: config.callbackURL
 }, function(accessToken, refreshToken, profile, done) {
@@ -310,7 +310,7 @@ app.get("/:id/json", function(req, res) {
         tag_url: {normal: tagUrl, max: tagUrl.replace(".png", ".max.png")},
         game_data: {last_played: lastPlayed, games: userData.games}
     }));
-})
+});
 
 app.listen(3000, async function() {
     // cleanCache();

--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@ passport.deserializeUser(function(obj, done) {
 var scopes = ['identify'];
 
 passport.use(new DiscordStrategy({
-    clientID: "684886188603080716",
+    clientID: "737308231986315348",
     clientSecret: config.clientSecret,
     callbackURL: config.callbackURL
 }, function(accessToken, refreshToken, profile, done) {
@@ -254,8 +254,15 @@ app.get("/Wiinnertag.xml", checkAuth, async function(req, res) {
 app.get("/:id", function(req, res) {
     // var key = req.params.id;
     // console.log(key);
+    var userData = getUserData(req.params.id);
+    if (userData == null) {
+        res.status(404).render("notfound.pug", {err: "Unknown user ID"});
+
+        return;
+    };
+
     res.render("tagpage.pug", {id: req.params.id,
-                               user: getUserData(req.params.id),
+                               user: userData,
                                backgrounds: getBackgroundList(),
                                overlays: getOverlayList()
                               });
@@ -265,6 +272,45 @@ app.get("/:id", function(req, res) {
 //     // display a page with the user's jstring and allow them to edit it manually.
 //     // this is super dangerous lmao
 // });
+
+app.get("/:id/json", function(req, res) {
+    var userData = getUserData(req.params.id);
+    res.type("application/json");
+
+    if (!userData) {
+        res.status(404).send(JSON.stringify({error: "That user ID does not exist."}));
+
+        return;
+    };
+
+    var lastPlayed = {};
+    if (userData.lastplayed !== null) {
+        var banner = new Banner(JSON.stringify(userData), doMake=false);
+        var game = userData.lastplayed[0];
+        var time = userData.lastplayed[1];
+        var gameid = game.split("-")[1]
+
+        var consoletype = banner.getConsoleType(game);
+        var covertype = banner.getCoverType(consoletype);
+        var region = banner.getGameRegion(gameid);
+        var extension = banner.getExtension(covertype, consoletype);
+
+        var lastPlayed = {
+            game_id: gameid,
+            console: consoletype,
+            region: region,
+            cover_url: banner.getCoverUrl(consoletype, covertype, region, gameid, extension),
+            time: time
+        };
+    };
+
+    var tagUrl = `https://tag.rc24.xyz/${userData.id}/tag.png`;
+    res.send(JSON.stringify({
+        user: {name: userData.name, id: userData.id},
+        tag_url: {normal: tagUrl, max: tagUrl.replace(".png", ".max.png")},
+        game_data: {last_played: lastPlayed, games: userData.games}
+    }));
+})
 
 app.listen(3000, async function() {
     // cleanCache();
@@ -329,8 +375,13 @@ function setUserAttrib(id, key, value) {
 
 function getUserData(id) {
     var p = path.resolve(dataFolder, "users", id + ".json");
-    var jdata = JSON.parse(fs.readFileSync(p));
-    return jdata || null;
+    try {
+        var jdata = JSON.parse(fs.readFileSync(p));
+    } catch(e) {
+        return null;
+    }
+    
+    return jdata;
 }
 
 async function createUser(user) {
@@ -339,6 +390,7 @@ async function createUser(user) {
             name: user.username,
             id: user.id,
             games: [],
+            last_played: {},
             coins: 0,
             friend_code: "0000 0000 0000 0000",
             region: "rc24",

--- a/src/index.js
+++ b/src/index.js
@@ -10,14 +10,14 @@ const dataFolder = path.resolve(__dirname, "..", "data");
 // const outpath = path.resolve(__dirname, "banner.png"); // debug variable
 
 class Tag extends events.EventEmitter{
-    constructor(user, size) {
+    constructor(user, size, doMake=true) {
         super();
 
         this.size = size;
         this.user = this.loadUser(user);
         this.overlay = this.loadOverlay(this.user.overlay);
 
-        this.makeBanner();
+        if (doMake) this.makeBanner();
     }
 
     loadUser(json_string) {
@@ -169,12 +169,16 @@ class Tag extends events.EventEmitter{
         }
     }
 
+    getCoverUrl(consoletype, covertype, region, game, extension) {
+        return `https://art.gametdb.com/${consoletype}/${covertype}/${region}/${game}.${extension}`;
+    }
+
     async downloadGameCover(game, region, covertype, consoletype, extension) {
         var can = new Canvas.Canvas(this.getCoverWidth(covertype), this.getCoverHeight(covertype, consoletype));
         var con = can.getContext("2d");
         var img;
 
-        img = await this.getImage(`https://art.gametdb.com/${consoletype}/${covertype}/${region}/${game}.${extension}`);
+        img = await this.getImage(this.getCoverUrl(consoletype, covertype, region, game, extension));
         con.drawImage(img, 0, 0, this.getCoverWidth(covertype), this.getCoverHeight(covertype, consoletype));
         await this.savePNG(path.resolve(dataFolder, "cache", `${consoletype}-${covertype}-${game}-${region}.png`), can);
     }


### PR DESCRIPTION
This PR adds some features and improves existing ones:
- Adds a JSON API accessible at `/{userID}/json` to retrieve some basic info
- `getUserData()` now returns `null` for users that do not exist
- The `/{userID}` endpoint now properly renders `notfound.pug` instead of showing a raw stack trace when a user ID is not found (using the above change)
- The `Tag` class constructor in `index.js` now has a new (backwards compatible) `doMake` parameter which, when set to `false` prevents `makeBanner()` from being called, allowing you to use the class's features without unnecessarily generating a tag image.

Please do check for bugs or inconsistencies or whatever, I'm not very fluent in JS.