### PR TITLE
Fix api error for new accounts

### DIFF
--- a/app.js
+++ b/app.js
@@ -284,7 +284,7 @@ app.get("/:id/json", function(req, res) {
     };
 
     var lastPlayed = {};
-    if (userData.lastplayed !== null) {
+    if (userData.lastplayed.length !== 0) {
         var banner = new Banner(JSON.stringify(userData), doMake=false);
         var game = userData.lastplayed[0];
         var time = userData.lastplayed[1];
@@ -390,7 +390,7 @@ async function createUser(user) {
             name: user.username,
             id: user.id,
             games: [],
-            last_played: {},
+            lastplayed: [],
             coins: 0,
             friend_code: "0000 0000 0000 0000",
             region: "rc24",


### PR DESCRIPTION
Fixes a quick error in the JSON API that would cause a crash when `userData.lastplayed` was not set.