### PR TITLE
Fix Overlay 3 (Small) Not Rendering

### DIFF
--- a/data/overlays/overlay3.json
+++ b/data/overlays/overlay3.json
@@ -45,5 +45,11 @@
         "x": -25,
         "y": 380
     },
+    "avatar": {
+        "size": 0
+    },
+    "mii": {
+        "size": 0
+    },
     "enabled": true
 }


### PR DESCRIPTION
While I was working on something I noticed a small bug where Overlay 3 (Small Overlay) wouldn't render.

Apparently removing the "avatar" and "mii" fields messes up the tag render pipeline and causes it to not be able to re-render the tag until the overlay type is changed.

I fixed this by adding in the Avatar and Mii fields with `"size": 0` as data to overlay3.json.