### PR TITLE
3 Quick Hotfixs for Mii Gen2 Support

### DIFF
--- a/public/edit.js
+++ b/public/edit.js
@@ -240,7 +240,11 @@ document.getElementById('mii-QRfile').onchange = async function () {
             });
         document.getElementById("mii-data").value = mii;
     } catch (e) {
-        console.log('Error when fetching', e);
+        if (e instanceof TypeError) {
+            showMiiError("Unable to use this QR code. Try again!");
+        } else {
+            console.log('Error when fetching', e);
+        }
     }
 }
 

--- a/public/edit.js
+++ b/public/edit.js
@@ -94,7 +94,7 @@ sel6.onchange = function () {
 
 sel7.onchange = function () {
     miiImg = document.getElementById("mii-img");
-
+    
     if (this.value == "Upload") {
         unhideMiiUpload();
         hideMiiGen2();
@@ -139,7 +139,9 @@ sel7.onchange = function () {
         miiImg.src = `/miis/guests/${user.mii_data}.png`;
     } else if (user.mii_data == "" || user.mii_data == null || user.mii_data.length >= 100) {
         miiImg.src = `/miis/guests/undefined.png`;
-    } else { 
+    } else if (user.mii_data.length == 94){
+        miiImg.src = `https://studio.mii.nintendo.com/miis/image.png?data=${user.mii_data}&amp;type=face&amp;width=512&amp;bgColor=FFFFFF00`;
+    } else {
         miiImg.src = `http://miicontestp.wii.rc24.xyz/cgi-bin/render.cgi?data=${user.mii_data}`;
     }
 }
@@ -161,6 +163,8 @@ sel8.onchange = function () {
             miiImg.src = `/miis/guests/${user.mii_data}.png`;
         } else if (user.mii_data == "" || user.mii_data == null || user.mii_data.length >= 100) {
             miiImg.src = `/miis/guests/undefined.png`;
+        } else if (user.mii_data.length == 94){
+            miiImg.src = `https://studio.mii.nintendo.com/miis/image.png?data=${user.mii_data}&amp;type=face&amp;width=512&amp;bgColor=FFFFFF00`;
         } else {
             miiImg.src = `http://miicontestp.wii.rc24.xyz/cgi-bin/render.cgi?data=${user.mii_data}`;
         }
@@ -231,7 +235,7 @@ document.getElementById('mii-QRfile').onchange = async function () {
     var data = document.getElementById('mii-QRfile').files[0];
     formData.append("platform", "gen2");
     formData.append("data", data);
-
+    hideMiiError();
     try {
         let r = await fetch('https://miicontestp.wii.rc24.xyz/cgi-bin/studio.cgi', {method: "POST", body: formData})
             .then(response => response.json())
@@ -239,6 +243,8 @@ document.getElementById('mii-QRfile').onchange = async function () {
                 mii = data.mii;
             });
         document.getElementById("mii-data").value = mii;
+        miiImg.src = `https://studio.mii.nintendo.com/miis/image.png?data=${mii}&amp;type=face&amp;width=512&amp;bgColor=FFFFFF00`;
+        showMiiSuccess();
     } catch (e) {
         if (e instanceof TypeError) {
             showMiiError("Unable to use this QR code. Try again!");
@@ -250,6 +256,7 @@ document.getElementById('mii-QRfile').onchange = async function () {
 
 document.getElementById('mii-file').onchange = function () {
     var file = document.getElementById('mii-file').files[0];
+    hideMiiError();
     if (!file) {
         console.log("No file");
         showMiiError("No file has been selected.");

--- a/views/edit.pug
+++ b/views/edit.pug
@@ -200,7 +200,7 @@ block content
                                                         b.alert-success Your Mii has successfully been uploaded!
                                                     h5.mb-0 Mii Preview
                                                     - var miiImg
-                                                    - if (guestList.includes(jdata.mii_data)) { miiImg = `/miis/guests/${jdata.mii_data}.png`; } else if (jdata.mii_data == "" || jdata.mii_data == null || jdata.mii_data.length >= 100) { miiImg = `/miis/guests/undefined.png`; } else { miiImg = `http://miicontestp.wii.rc24.xyz/cgi-bin/render.cgi?data=${jdata.mii_data}`; }
+                                                    - if (guestList.includes(jdata.mii_data)) { miiImg = `/miis/guests/${jdata.mii_data}.png`; } else if (jdata.mii_data == "" || jdata.mii_data == null || jdata.mii_data.length >= 100) { miiImg = `/miis/guests/undefined.png`; } else if (jdata.mii_data.length == 94) { miiImg = `https://studio.mii.nintendo.com/miis/image.png?data=${jdata.mii_data}&amp;type=face&amp;width=512&amp;bgColor=FFFFFF00`; } else { miiImg = `http://miicontestp.wii.rc24.xyz/cgi-bin/render.cgi?data=${jdata.mii_data}`; }
                                                     img(src=miiImg width="25%" id="mii-img" alt="Mii Preview").no-shadow
                                                     h5.mb-0 Select a Mii
                                                     select.big-space-top.space-bottom#mii-select

--- a/views/edit.pug
+++ b/views/edit.pug
@@ -267,7 +267,10 @@ block content
                                                         div#mii-gen2(style="")
                                                             +miiQRUploadBox
                                                     input#mii-data(type="text" name="miidata" style="display: none;" value=jdata.mii_data)
-                                                    input#mii-type(type="text" name="MiiType" style="display: none;" value="")
+                                                    if guestList.includes(jdata.mii_data)
+                                                        input#mii-type(type="text" name="MiiType" style="display: none;" value="Guest")
+                                                    if !guestList.includes(jdata.mii_data)
+                                                        input#mii-type(type="text" name="MiiType" style="display: none;" value="CMOC")
                 .row
                     .col-md-12
                         .card.big-space-bottom


### PR DESCRIPTION
Fix 1 (Commit 4b133c3): Not changing the dropdown before submitting a CMOC code causes the value to not be correctly set and the Mii isn't re-rendered. This fixes that.

Fix 2 (Commit 23bb96f): Previously an unparsable QR silently failed, making it seem like there was a bug in the uploader. This fixes that.

Fix 3 (Commit efed10d): Honestly I knew this didn't work but I had left it for the time as RiiTag could have this issue previously itself. Through this commit and previous PR's near every contingency should be covered now so a Mii (or the undefined Mii) always shows for the /edit preview.

Fix 1 Applys to #36, Fix 2 and 3 apply to #37.