### PR TITLE
Add 3ds endpoint for RPC

### DIFF
--- a/app.js
+++ b/app.js
@@ -654,7 +654,7 @@ function getGameRegion(gameName, userRegion) {
             }
         }
         userRegion = "EU"; // Fallback
-    } else if (userRegion == "FR") {
+    } else if (userRegion != "EU") {
         for (IDs of ids[gameName]) {
             if (userRegion == "FR" && IDs.slice(-1) == "F") {
                 return IDs;

--- a/app.js
+++ b/app.js
@@ -191,26 +191,6 @@ app.get("/create", checkAuth, async function(req, res) {
     })
 });
 
-async function getTag(id, res) {
-    return new Promise(function(resolve, reject) {
-        try {
-            var jstring = fs.readFileSync(path.resolve(dataFolder, "users", `${id}.json`));
-            var banner = new Banner(jstring);
-            banner.once("done", function () {
-                try {
-                    res.redirect(`/${id}`);
-                } catch (e) {
-                    reject("Redirect");
-                }
-                resolve(banner);
-            });
-        } catch(e) {
-            console.log(e);
-            reject(e);
-        }
-    })
-}
-
 
 app.get("^/:id([0-9]+)/tag.png", async function(req, res) {
     try {
@@ -280,14 +260,10 @@ app.get("/wii", async function(req, res) {
     setUserAttrib(userID, "lastplayed", ["wii-" + gameID, Math.floor(Date.now() / 1000)]);
     res.status(200).send();
 
-    getTag(userID, res).catch((err) => {
-        if (err == "Redirect") {
-            res.redirect(`/${userID}`);
-        } else {
-            res.status(404).render("notfound.pug");
-            return;
-        }
-    })
+    var banner = await getTagEP(userID).catch(function () {
+        res.status(404).render("notfound.pug");
+        return
+    });
 });
 
 app.get("/wiiu", async function(req, res) {
@@ -322,14 +298,10 @@ app.get("/wiiu", async function(req, res) {
     setUserAttrib(userID, "lastplayed", ["wiiu-" + ids[gameTID], Math.floor(Date.now() / 1000)]);
     res.status(200).send();
 
-    getTag(userID, res).catch((err) => {
-        if (err == "Redirect") {
-            res.redirect(`/${userID}`);
-        } else {
-            res.status(404).render("notfound.pug");
-            return;
-        }
-    })
+    var banner = await getTagEP(userID).catch(function () {
+        res.status(404).render("notfound.pug");
+        return
+    });
 });
 
 app.get("/3ds", async function(req, res) {
@@ -366,14 +338,10 @@ app.get("/3ds", async function(req, res) {
     setUserAttrib(userID, "lastplayed", ["3ds-" + gameID, Math.floor(Date.now() / 1000)]);
     res.status(200).send();
 
-    getTag(userID, res).catch((err) => {
-        if (err == "Redirect") {
-            res.redirect(`/${userID}`);
-        } else {
-            res.status(404).render("notfound.pug");
-            return;
-        }
-    })
+    var banner = await getTagEP(userID).catch(function () {
+        res.status(404).render("notfound.pug");
+        return
+    });
 });
 
 app.get("/Wiinnertag.xml", checkAuth, async function(req, res) {
@@ -458,6 +426,41 @@ app.listen(port, async function() {
     // db.insert("users", ["snowflake", "key"], ["test_sf", "test_key"]);
     console.log("RiiTag Server listening on port " + port);
 });
+
+async function getTag(id, res) {
+    return new Promise(function(resolve, reject) {
+        try {
+            var jstring = fs.readFileSync(path.resolve(dataFolder, "users", `${id}.json`));
+            var banner = new Banner(jstring);
+            banner.once("done", function () {
+                try {
+                    res.redirect(`/${id}`);
+                } catch (e) {
+                    reject("Redirect");
+                }
+                resolve(banner);
+            });
+        } catch(e) {
+            console.log(e);
+            reject(e);
+        }
+    })
+}
+
+async function getTagEP(id) {
+    return new Promise(function(resolve, reject) {
+        try {
+            var jstring = fs.readFileSync(path.resolve(dataFolder, "users", `${id}.json`));
+            var banner = new Banner(jstring);
+            banner.once("done", function () {
+                resolve(banner);
+            });
+        } catch(e) {
+            console.log(e);
+            reject(e);
+        }
+    })
+}
 
 function checkAuth(req, res, next) {
     if (req.isAuthenticated()) return next();

--- a/app.js
+++ b/app.js
@@ -282,7 +282,7 @@ app.get("/wii", async function(req, res) {
 
     getTag(userID, res).catch((err) => {
         if (err == "Redirect") {
-            res.redirect(`/${id}`);
+            res.redirect(`/${userID}`);
         } else {
             res.status(404).render("notfound.pug");
             return;
@@ -324,7 +324,7 @@ app.get("/wiiu", async function(req, res) {
 
     getTag(userID, res).catch((err) => {
         if (err == "Redirect") {
-            res.redirect(`/${id}`);
+            res.redirect(`/${userID}`);
         } else {
             res.status(404).render("notfound.pug");
             return;
@@ -366,9 +366,9 @@ app.get("/3ds", async function(req, res) {
     setUserAttrib(userID, "lastplayed", ["3ds-" + gameID, Math.floor(Date.now() / 1000)]);
     res.status(200).send();
 
-    getTag(req.user.id, res).catch((err) => {
+    getTag(userID, res).catch((err) => {
         if (err == "Redirect") {
-            res.redirect(`/${id}`);
+            res.redirect(`/${userID}`);
         } else {
             res.status(404).render("notfound.pug");
             return;

--- a/app.js
+++ b/app.js
@@ -280,7 +280,7 @@ app.get("/wii", async function(req, res) {
     setUserAttrib(userID, "lastplayed", ["wii-" + gameID, Math.floor(Date.now() / 1000)]);
     res.status(200).send();
 
-    getTag(req.user.id, res).catch((err) => {
+    getTag(userID, res).catch((err) => {
         if (err == "Redirect") {
             res.redirect(`/${id}`);
         } else {
@@ -322,7 +322,7 @@ app.get("/wiiu", async function(req, res) {
     setUserAttrib(userID, "lastplayed", ["wiiu-" + ids[gameTID], Math.floor(Date.now() / 1000)]);
     res.status(200).send();
 
-    getTag(req.user.id, res).catch((err) => {
+    getTag(userID, res).catch((err) => {
         if (err == "Redirect") {
             res.redirect(`/${id}`);
         } else {

--- a/app.js
+++ b/app.js
@@ -637,59 +637,29 @@ function getGameRegion(gameName, userRegion) {
         This should hopefully create a safety net where there's always some region avalible.
         If not just return "ids[gameName][0]" to use the first entry for the game.
     */
+    for (IDs of ids[gameName]) {
+        var gameRegion = IDs.slice(-1);
+        if (userRegion == "FR" && gameRegion == "F") return IDs;
+        if (userRegion == "DE" && gameRegion == "D") return IDs;
+        if (userRegion == "ES" && gameRegion == "S") return IDs;
+        if (userRegion == "IT" && gameRegion == "I") return IDs;
+        if (userRegion == "NL" && gameRegion == "H") return IDs;
+        if (userRegion == "KO" && gameRegion == "K") return IDs;
+        if (userRegion == "TW" && gameRegion == "W") return IDs;
 
-    if (userRegion == "JP") {
-        for (IDs of ids[gameName]) {
-            if (IDs.slice(-1) == "J") {
-                return IDs;
-            }
-        }
-        userRegion = "EN"; // Fallback
-    } else if (userRegion == "EN") {
-        for (IDs of ids[gameName]) {
-            if (IDs.slice(-1) == "E") {
-                return IDs;
-            } else if (IDs.slice(-1) == "X" || IDs.slice(-1) == "Y" || IDs.slice(-1) == "Z") {
-                return IDs;
-            }
-        }
-        userRegion = "EU"; // Fallback
-    } else if (userRegion != "EU") {
-        for (IDs of ids[gameName]) {
-            if (userRegion == "FR" && IDs.slice(-1) == "F") {
-                return IDs;
-            } else if (userRegion == "DE" && IDs.slice(-1) == "D") {
-                return IDs;
-            } else if (userRegion == "ES" && IDs.slice(-1) == "S") {
-                return IDs;
-            } else if (userRegion == "IT" && IDs.slice(-1) == "I") {
-                return IDs;
-            } else if (userRegion == "NL" && IDs.slice(-1) == "H") {
-                return IDs;
-            } else if (userRegion == "KO" && IDs.slice(-1) == "K") {
-                return IDs;
-            } else if (userRegion == "TW" && IDs.slice(-1) == "W") {
-                return IDs;
-            } else {
-                userRegion == "EU";
-            }
-        }
-        userRegion = "EU"; // Fallback
-    } else if (userRegion == "EU") {
-        for (IDs of ids[gameName]) {
-            if (IDs.slice(-1) == "P") {
-                return IDs;
-            } else if (IDs.slice(-1) == "V") {
-                return IDs;
-            } else if (IDs.slice(-1) == "X" || IDs.slice(-1) == "Y" || IDs.slice(-1) == "Z") {
-                return IDs;
-            } else if (IDs.slice(-1) == "J") {
-                return IDs;
-            } 
-        }
+        if (userRegion == "JP" && gameRegion == "J") return IDs;
+        if (userRegion == "JP") userRegion = "EN"; // Fallback
+        
+        if (userRegion == "EN" && gameRegion == "E") return IDs;
+        if (userRegion == "EN" && (gameRegion == "X" || gameRegion == "Y" || gameRegion == "Z")) return IDs;
+
+        if (gameRegion == "P") return IDs;
+        if (gameRegion == "V") return IDs;
+        if (gameRegion == "X" || gameRegion == "Y" || gameRegion == "Z") return IDs;
+        if (gameRegion == "E") return IDs;
+        if (gameRegion == "J") return IDs;
     }
-
-    // Incase nothing was found, return the first ID.
+    // In case nothing was found, return the first ID.
     return ids[gameName][0];
 }
 

--- a/app.js
+++ b/app.js
@@ -621,7 +621,7 @@ function loadConfig() {
     return JSON.parse(fs.readFileSync("config.json"));
 }
 
-function getGameRegion(gameName, userRegion) {
+function getGameRegion(gameName, coverRegion) {
     var ids = JSON.parse(fs.readFileSync(path.resolve(dataFolder, "ids", "3ds.json"))) // 16 digit TID -> 4 or 6 digit game ID
 
     if (!ids[gameName][1]) { // Prevent pointless searching for a proper region
@@ -637,8 +637,11 @@ function getGameRegion(gameName, userRegion) {
         This should hopefully create a safety net where there's always some region avalible.
         If not just return "ids[gameName][0]" to use the first entry for the game.
     */
+
     for (IDs of ids[gameName]) {
         var gameRegion = IDs.slice(-1);
+        var userRegion = coverRegion;
+
         if (userRegion == "FR" && gameRegion == "F") return IDs;
         if (userRegion == "DE" && gameRegion == "D") return IDs;
         if (userRegion == "ES" && gameRegion == "S") return IDs;

--- a/data/ids/3ds.json
+++ b/data/ids/3ds.json
@@ -1,0 +1,4086 @@
+{
+    "100\uff05 PASUKARU SENSEI\\nPerfect Paint Bombers": [
+        "BP4J"
+    ],
+    "12 SAI TOROKERU Puzzle\\nFUTARINO Harmony": [
+        "A2PJ"
+    ],
+    "12 SAI\\nHONTOU NO KIMOCHI": [
+        "BTVJ"
+    ],
+    "12 SAI\\nKOISURU Diary": [
+        "BA7J"
+    ],
+    "2in1: Horses 3D, Vol. 2": [
+        "BMRP"
+    ],
+    "2in1: Horses 3D, Vol. 3": [
+        "BM2P"
+    ],
+    "2in1: Horses 3D": [
+        "BMFP"
+    ],
+    "2in1:LifeHorses3D\\n+BabyPetHotel3D": [
+        "BMXP"
+    ],
+    "2in1:VetCountry3D\\n+BabyPetHotel3D": [
+        "BELP"
+    ],
+    "35 Classic Games": [
+        "AF5P"
+    ],
+    "3D Game Collection": [
+        "AD3D",
+        "AD3P"
+    ],
+    "3D MahJongg": [
+        "AG2P"
+    ],
+    "3in1 Horses": [
+        "BRZP"
+    ],
+    "4 Elements": [
+        "AELP"
+    ],
+    "50 Classic Games 3D": [
+        "AF6Z"
+    ],
+    "50 Classic Games": [
+        "AC5E",
+        "AF6P"
+    ],
+    "7TH DRAGON III CODE: VFD": [
+        "BD7E",
+        "BD7P"
+    ],
+    "7TH DRAGON \u2162 code:VFD": [
+        "BD7J"
+    ],
+    "A Penguin's Troubles +": [
+        "AYSJ"
+    ],
+    "A-Train 3D NEO": [
+        "BN3J"
+    ],
+    "A-Train 3D": [
+        "AALJ"
+    ],
+    "ACE COMBAT 3D\\nCROSS RUMBLE": [
+        "AC3J"
+    ],
+    "ACE COMBAT\\nAH LEGACY +": [
+        "BCRE",
+        "BCRP"
+    ],
+    "ACE COMBAT\\nASSAULT HORIZON LEGACY": [
+        "AC3E",
+        "AC3P"
+    ],
+    "ACECOMBAT 3D\\nCROSSRUMBLE +": [
+        "BCRJ"
+    ],
+    "AIKATSU! Cinderella Lesson": [
+        "AEKJ"
+    ],
+    "AKB48+Me": [
+        "AKBJ"
+    ],
+    "ALLIANCE ALIVE": [
+        "AL4J"
+    ],
+    "AT:  FJI": [
+        "BFNE",
+        "BFNP"
+    ],
+    "AZITO 3D": [
+        "AZTJ"
+    ],
+    "AZURE STRIKER GUNVOLT:\\nSTRIKER PACK": [
+        "BG8E"
+    ],
+    "Adventure Time: ETDBIDK": [
+        "AY9E",
+        "AY9P"
+    ],
+    "Adventure Time: The Secret\\nof the Nameless Kingd": [
+        "AVTE",
+        "AVTJ",
+        "AVTP"
+    ],
+    "Adventure Time\u2122 Hey Ice King!": [
+        "AD4E"
+    ],
+    "Alien Chaos 3D": [
+        "AM2E"
+    ],
+    "American Mensa Academy": [
+        "AMME"
+    ],
+    "Angler's Club\\nUltimate Bass Fishing 3D": [
+        "AFDJ",
+        "AFDP"
+    ],
+    "Angry Birds Star Wars": [
+        "ANDE",
+        "ANDP"
+    ],
+    "Angry Birds Trilogy": [
+        "ANGE",
+        "ANGP"
+    ],
+    "Animal Crossing New Leaf": [
+        "EGDJ",
+        "EGDK"
+    ],
+    "Animal Crossing: New Leaf -\\nWelcome amiibo": [
+        "EAAE",
+        "EAAJ",
+        "EAAP"
+    ],
+    "Animal Crossing: New Leaf": [
+        "EGDE",
+        "EGDP"
+    ],
+    "Animal Crossing:\\nHappy Home Designer": [
+        "EDHE",
+        "EDHJ",
+        "EDHP"
+    ],
+    "Animal Hospital": [
+        "AZFP"
+    ],
+    "Anpanman to asobo\\nnew aiueo kyoushitsu": [
+        "AEWJ"
+    ],
+    "Apollo Justice: Ace Attorney": [
+        "AXRJ"
+    ],
+    "Arcade Classics 3D": [
+        "ARDP"
+    ],
+    "Are You Smarter Than a\\n5th Grader?": [
+        "BY5E"
+    ],
+    "Around the World with\\nHello Kitty and Friends": [
+        "AHKP",
+        "AHKZ"
+    ],
+    "Art Academy\\nLessons for Everyone!": [
+        "AACE"
+    ],
+    "Asphalt 3D: Nitro Racing": [
+        "ASFJ"
+    ],
+    "Asphalt 3D": [
+        "ASFE",
+        "ASFP"
+    ],
+    "Asterix\\nThe Mansions of the Gods": [
+        "BMNP"
+    ],
+    "Atlantic Quest": [
+        "BAQP"
+    ],
+    "Atooi Collection": [
+        "AUTE"
+    ],
+    "Attack on Titan\\nEscape from death": [
+        "AEVJ"
+    ],
+    "Azada": [
+        "AZDP"
+    ],
+    "BEASTSAGA": [
+        "BEAJ"
+    ],
+    "BEN 10 OMNIVERSE\u2122 2": [
+        "AEQE",
+        "AEQP"
+    ],
+    "BEN 10 OMNIVERSE\u2122": [
+        "ABVE",
+        "ABVP"
+    ],
+    "BEYBLADE EVOLUTION": [
+        "ARXE",
+        "ARXP",
+        "BBBJ"
+    ],
+    "BIOHAZARD\u00ae\\nREVELATIONS": [
+        "ABRJ",
+        "ABRK",
+        "ABRW"
+    ],
+    "BIOHAZARD\u00ae\\nTHE MERCENARIES 3D": [
+        "ABMJ"
+    ],
+    "BIT.TRIP SAGA": [
+        "ABTE",
+        "ABTP"
+    ],
+    "BLAZBLUE\\nCONTINUUM SHIFT \u2161": [
+        "ABLJ",
+        "ABLP",
+        "ABLZ"
+    ],
+    "BRAVE COMPANY": [
+        "AYGJ"
+    ],
+    "BRAVELY DEFAULT": [
+        "BTRE",
+        "BTRP"
+    ],
+    "BRAVELY SECOND": [
+        "BSED",
+        "BSEE"
+    ],
+    "BUST-A-MOVE UNIVERSE": [
+        "ABBE"
+    ],
+    "Barbie Dreamhouse Party": [
+        "AAVE",
+        "AAVP"
+    ],
+    "Barbie and Her Sisters\\nPuppy Rescue": [
+        "BRQE",
+        "BRQP",
+        "BRQZ"
+    ],
+    "Barbie\u2122\\nGroom and Glam Pups\u2122": [
+        "ABYE",
+        "ABYP"
+    ],
+    "Batman\u2122:\\nArkham Origins Blackgate": [
+        "AZEE",
+        "AZEP"
+    ],
+    "Battleship\u2122": [
+        "ABSE",
+        "ABSP"
+    ],
+    "Beautician debut story": [
+        "BYCJ"
+    ],
+    "Bella Sara 2\\nThe Magic of Drasilmare": [
+        "AY7P"
+    ],
+    "Bella Sara\\nThe Magical Horse Adventures": [
+        "AB2P"
+    ],
+    "Ben 10\u2122 Galactic Racing": [
+        "ABNE",
+        "ABNP"
+    ],
+    "Best Friends -\\nMy Horse 3D": [
+        "BMEP"
+    ],
+    "Best of Arcade Games": [
+        "AYHP"
+    ],
+    "Best of Board Games": [
+        "AYFP"
+    ],
+    "Best of Casual Games": [
+        "BCSP"
+    ],
+    "Bibi Blocksberg - Das gro\u00dfe\\nHexenbesen-Rennen 2": [
+        "AA3D"
+    ],
+    "Bibi&Tina\\nDas Spiel zum Kinofilm": [
+        "BBTD"
+    ],
+    "BonBon Ribbon\\nKiraKiraDance": [
+        "AVRJ"
+    ],
+    "Boulder Dash\u00ae-XL 3D\u2122": [
+        "ABZE",
+        "ABZP"
+    ],
+    "Bowling Bonanza 3D": [
+        "AB6P"
+    ],
+    "Brain Age\\nConcentration Training": [
+        "ASRE"
+    ],
+    "Brain Training 3D": [
+        "AKTP"
+    ],
+    "Bratz\u00ae: Fashion Boutique": [
+        "AB5E"
+    ],
+    "Brilliant Hamsters!": [
+        "AHMJ"
+    ],
+    "Brunswick Pro Bowling": [
+        "ABWE"
+    ],
+    "CARDFIGHT!! Vanguard\\nLOCK ON VICTORY!!": [
+        "BVGJ"
+    ],
+    "CARDFIGHT!! Vanguard\\nRide To Victory!!": [
+        "AVGJ"
+    ],
+    "CODE OF PRINCESS": [
+        "AC7E",
+        "AC7J"
+    ],
+    "CONCEPTION\u2161\\n\u4e03\u661f\u306e\u5c0e\u304d\u3068\u30de\u30ba\u30eb\u306e\u60aa\u5922": [
+        "BCCJ"
+    ],
+    "CRASH CITY MAYHEM": [
+        "AC2E"
+    ],
+    "CRAZY CONSTRUCTION": [
+        "BCZP"
+    ],
+    "CRUSH\u21223D": [
+        "ACRE",
+        "ACRJ",
+        "ACRP"
+    ],
+    "Candy Match 3": [
+        "BCMP"
+    ],
+    "Captain America\u2122: Super Soldier": [
+        "ACAE",
+        "ACAP"
+    ],
+    "Captain Toad: Treasure Tracker": [
+        "BZPE",
+        "BZPJ",
+        "BZPP"
+    ],
+    "Cardfight!! VanguardG\\nSTRIDE TO VICTORY!!": [
+        "BCFJ"
+    ],
+    "Carnival Games\u00ae Wild West 3D": [
+        "AW2E"
+    ],
+    "Carnival Games\u2122 Wild West 3D": [
+        "AW2P"
+    ],
+    "Cars 2": [
+        "AAZE",
+        "AAZP",
+        "AAZZ"
+    ],
+    "Cartoon Network:Battle Crashers": [
+        "BRWE",
+        "BRWZ"
+    ],
+    "Cartoon Network\\nPunch Time Explosion": [
+        "ACNE",
+        "ACNP"
+    ],
+    "Cartoonist debut story": [
+        "BGHJ"
+    ],
+    "Castlevania: Lords of Shadow\\nMirror of Fate": [
+        "ACFE",
+        "ACFJ",
+        "ACFP"
+    ],
+    "Cats & Dogs\\nPets at play": [
+        "AHUP"
+    ],
+    "Cave Story 3D": [
+        "ACVE",
+        "ACVP"
+    ],
+    "Centipede: Infestation": [
+        "ACPE"
+    ],
+    "Chara Pet": [
+        "BKPJ"
+    ],
+    "Chevrolet\u00aeCamaro\u2122Wild Ride 3D": [
+        "ACWP"
+    ],
+    "Chibi-Robo! Zip Lash": [
+        "BXLE",
+        "BXLJ",
+        "BXLP"
+    ],
+    "Classic Games Overload:\\nCard & Puzzle Edition": [
+        "ACGE"
+    ],
+    "Cloudy with a Chance\\nof Meatballs 2": [
+        "AD5E",
+        "AD5P",
+        "AD5Z"
+    ],
+    "Cocoto Alien Brick Breaker": [
+        "AB7P"
+    ],
+    "Code Name: S.T.E.A.M.": [
+        "AY6A"
+    ],
+    "Combat of Giants:\\nDinosaurs 3D": [
+        "ATTE",
+        "ATTJ",
+        "ATTP"
+    ],
+    "Conan\u3000Marionettesymphony": [
+        "BKNJ"
+    ],
+    "Conception II:\\nChildren of the Seven Stars": [
+        "BCCE"
+    ],
+    "Cooking Mama 5: Bon Appetit!": [
+        "BC5E"
+    ],
+    "Cooking Mama: Bon App\u00e9tit!": [
+        "BC5P"
+    ],
+    "Cooking Mama: Sweet Shop": [
+        "BS8E",
+        "BS8P"
+    ],
+    "Corpse Party": [
+        "BCPE"
+    ],
+    "Crash Time 3D": [
+        "AFBP"
+    ],
+    "Crosswords Plus": [
+        "AQ8E"
+    ],
+    "Cube Creator DX": [
+        "A9CJ"
+    ],
+    "Cubic Ninja": [
+        "AQNE",
+        "AQNJ",
+        "AQNP"
+    ],
+    "Culdcept Revolt": [
+        "AY3E",
+        "AY3J",
+        "AY3P"
+    ],
+    "Culdcept": [
+        "ACBJ"
+    ],
+    "Cut the Rope\u00ae\\nTriple Treat": [
+        "BR3E",
+        "BR3P"
+    ],
+    "DEAD OR ALIVE Dimensions": [
+        "ADDE",
+        "ADDJ",
+        "ADDP"
+    ],
+    "DECA SPORTA\\n3D SPORTS": [
+        "ADEJ"
+    ],
+    "DECA SPORTS EXTREME": [
+        "ADEE"
+    ],
+    "DETECTIVE CONAN\\nPHANTOM RHAPSODY": [
+        "BKRJ"
+    ],
+    "DISNEY/PIXAR FINDING NEMO:\\nESCAPE TO THE BIG BLU": [
+        "AF7P",
+        "AF7X"
+    ],
+    "DISNEY/PIXAR FINDING NEMO\\nESCAPE TO THE BIG BLUE": [
+        "AF7E"
+    ],
+    "DQM2": [
+        "BDMJ"
+    ],
+    "DQMJOKER3 PRO": [
+        "BDQJ"
+    ],
+    "DQMJOKER3": [
+        "BJ3J"
+    ],
+    "DQMT": [
+        "ATWJ"
+    ],
+    "DRAGON BALL FUSIONS": [
+        "BDLE",
+        "BDLP"
+    ],
+    "DRAGON BALL Z:\\nExtreme Butoden": [
+        "BDVE",
+        "BDVP"
+    ],
+    "DRAGON QUEST VII": [
+        "AD7E",
+        "AD7J",
+        "AD7P"
+    ],
+    "DRAGON QUEST XI": [
+        "BTZJ"
+    ],
+    "Deer Drive Legends": [
+        "AD2E"
+    ],
+    "Derby Stallion GOLD": [
+        "BDSJ"
+    ],
+    "Detective Pikachu": [
+        "A98A"
+    ],
+    "Devil Summoner: Soul Hackers": [
+        "AHQJ"
+    ],
+    "Devil Survivor 2:\\nRecord Breaker": [
+        "ADXP"
+    ],
+    "Devil Survivor 2\\nRecord Breaker": [
+        "ADXE"
+    ],
+    "Devilish Brain Training\\nCan you stay focused?": [
+        "ASRP",
+        "ASRW"
+    ],
+    "Die drei ??? Kids\\nJagd auf das Phantom": [
+        "BD4D"
+    ],
+    "Dillon's Dead-Heat Breakers": [
+        "A9EJ",
+        "A9EP"
+    ],
+    "Disney 2-Pack": [
+        "BF6Z"
+    ],
+    "Disney Art Academy": [
+        "BWDE",
+        "BWDJ",
+        "BWDP"
+    ],
+    "Disney Big Hero 6:\\nBattle in the Bay": [
+        "BH6E",
+        "BH6P",
+        "BH6Z"
+    ],
+    "Disney Epic Mickey:\\nPower of Illusion": [
+        "AECE",
+        "AECP",
+        "AECX"
+    ],
+    "Disney Frozen - Big Hero 6": [
+        "BF6E"
+    ],
+    "Disney Frozen: Olaf's Quest": [
+        "AEHE",
+        "AEHJ",
+        "AEHP"
+    ],
+    "Disney Frozen:\\nOlaf\u2019s Quest": [
+        "AEHZ"
+    ],
+    "Disney Infinity:\\nToy Box Challenge": [
+        "ADYE"
+    ],
+    "Disney Infinity": [
+        "ADYP",
+        "ADYZ"
+    ],
+    "Disney Magic Castle\\nMy Happy Life": [
+        "AMQJ"
+    ],
+    "Disney Magical World 2": [
+        "BD2E",
+        "BD2P"
+    ],
+    "Disney Magical World": [
+        "AMQE",
+        "AMQP"
+    ],
+    "Disney Planes\\nFire & Rescue": [
+        "BPRE",
+        "BPRP"
+    ],
+    "Disney Planes": [
+        "APNE",
+        "APNP",
+        "APNR",
+        "APNY",
+        "APNZ"
+    ],
+    "Disney Princess\\nMy Fairytale Adventure": [
+        "ADPE",
+        "ADPP",
+        "ADPX"
+    ],
+    "Disney Princesses\\nMon Royaume Enchant\u00e9": [
+        "ADPD"
+    ],
+    "Disney Violetta: Rhythm & Music": [
+        "BGRP"
+    ],
+    "Disney Wreck-It Ralph": [
+        "AWRE",
+        "AWRP"
+    ],
+    "Doctor Lautrec\\nand the Forgotten Knights": [
+        "ADLE",
+        "ADLJ",
+        "ADLP"
+    ],
+    "DokiDoki! Precure": [
+        "BPQJ"
+    ],
+    "Dolly Kanon": [
+        "BJWJ"
+    ],
+    "Donkey Kong Returns 3D": [
+        "AYTJ"
+    ],
+    "Donkey Kong\\nCountry Returns 3D": [
+        "AYTE",
+        "AYTP"
+    ],
+    "Dorachie": [
+        "BDCJ"
+    ],
+    "Doraeigo": [
+        "BDEJ"
+    ],
+    "Doraemon": [
+        "ADWW"
+    ],
+    "Doramoji": [
+        "BKVJ"
+    ],
+    "Downtown Nekketsu Jidaigeki": [
+        "BNJJ"
+    ],
+    "Dragon Ball Heroes\\nUltimate Mission": [
+        "ADGJ"
+    ],
+    "Dragon Quest VIII": [
+        "BQ8E",
+        "BQ8J",
+        "BQ8P"
+    ],
+    "Dream Trigger\u2122 3D": [
+        "ADTE",
+        "ADTP"
+    ],
+    "DreamWorks Combo Pack": [
+        "AGCP"
+    ],
+    "DreamWorks\u00ae\\nSuper Star Kartz\u2122": [
+        "AKZE",
+        "AKZP"
+    ],
+    "Driver\u00ae Renegade 3D": [
+        "ADRP"
+    ],
+    "Driver\u00ae Renegade": [
+        "ADRE"
+    ],
+    "DualPenSports": [
+        "APPE",
+        "APPP"
+    ],
+    "Duck Dynasty\u00ae": [
+        "BDKE"
+    ],
+    "Dynasty Warriors VS": [
+        "AS5J"
+    ],
+    "ESSE\u3089\u304f\u3089\u304f\u5bb6\u8a08\u7c3f": [
+        "AEZJ"
+    ],
+    "ETRIAN MYSTERY DUNGEON": [
+        "BFDE"
+    ],
+    "ETRIAN ODYSSEY V:\\nBEYOND THE MYTH": [
+        "BMZP"
+    ],
+    "EXSTETRA": [
+        "BEXJ"
+    ],
+    "Earthpedia": [
+        "AEPJ"
+    ],
+    "El profesor Layton\\ny el legado de los ashalanti": [
+        "AL6S"
+    ],
+    "El profesor Layton\\ny la m\u00e1scara de los prodigios": [
+        "AKKS"
+    ],
+    "Elminage Gothic 3D REMIX\\n-Ulm Zakiher and Dark R": [
+        "AEUJ"
+    ],
+    "Elminage Ibun\\nAme no Mihashira Kai": [
+        "BAMJ"
+    ],
+    "Etrian Mystery Dungeon": [
+        "BFDP"
+    ],
+    "Etrian Odyssey 2 Untold:\\nThe Fafnir Knight": [
+        "BM9E",
+        "BM9P"
+    ],
+    "Etrian Odyssey IV\\nLegends of the Titan": [
+        "ASJE",
+        "ASJP"
+    ],
+    "Etrian Odyssey Nexus": [
+        "BZME",
+        "BZMP"
+    ],
+    "Etrian Odyssey Untold 2\\nKnight of Fafnir": [
+        "BM9J"
+    ],
+    "Etrian Odyssey Untold\\nMaiden of Millennium": [
+        "BSKJ"
+    ],
+    "Etrian Odyssey Untold\\nThe Millennium Girl": [
+        "BSKE",
+        "BSKP"
+    ],
+    "Etrian Odyssey V:\\nBeyond the Myth": [
+        "BMZE"
+    ],
+    "Etrian Odyssey V\\nBeyond the Legends": [
+        "BMZJ"
+    ],
+    "Etrian Odyssey X": [
+        "BZMJ"
+    ],
+    "Ever Oasis": [
+        "BAGE",
+        "BAGJ",
+        "BAGP"
+    ],
+    "F1 2011": [
+        "AF4E",
+        "AF4J",
+        "AF4P"
+    ],
+    "FANTASY LIFE LINK!": [
+        "BLKJ"
+    ],
+    "FANTASY LIFE": [
+        "AFLJ"
+    ],
+    "FIFA 12": [
+        "AF2D",
+        "AF2P"
+    ],
+    "FIFA 13": [
+        "AF8D",
+        "AF8P"
+    ],
+    "FIFA 14": [
+        "AFYD",
+        "AFYP"
+    ],
+    "FIFA 15": [
+        "BFTD",
+        "BFTP"
+    ],
+    "FIFA Soccer 12": [
+        "AF2E"
+    ],
+    "FIFA Soccer 13": [
+        "AF8E"
+    ],
+    "FIFA Soccer 14": [
+        "AFYE"
+    ],
+    "FIFA Soccer 15": [
+        "BFTE"
+    ],
+    "FINAL FANTASY  EXPLORERS": [
+        "BCEJ"
+    ],
+    "FINAL FANTASY EXPLORERS": [
+        "BCEE",
+        "BCEP"
+    ],
+    "FIREMAN SAM\\nTO THE RESCUE!": [
+        "AFTP"
+    ],
+    "FISH ON": [
+        "AFAJ"
+    ],
+    "FabStyle": [
+        "AFVJ"
+    ],
+    "Face Racers: Photo Finish": [
+        "AFCE"
+    ],
+    "Fantasy Life\u2122": [
+        "AFLE",
+        "AFLP"
+    ],
+    "Farming Simulator 14": [
+        "BFSE",
+        "BFSJ",
+        "BFSP"
+    ],
+    "Farming Simulator 18": [
+        "A8FE",
+        "A8FJ",
+        "A8FP"
+    ],
+    "Farming Simulator 2012 3D": [
+        "AL3P"
+    ],
+    "Farming Simulator 3D": [
+        "AL3J"
+    ],
+    "Farmscapes": [
+        "AF9F"
+    ],
+    "Fast & Furious\u2122: Showdown": [
+        "AFHE",
+        "AFHP"
+    ],
+    "Fate/kaleid liner\\n\u30d7\u30ea\u30ba\u30de\u2606\u30a4\u30ea\u30e4": [
+        "AYLJ"
+    ],
+    "Fire Emblem Awakening": [
+        "AFEE"
+    ],
+    "Fire Emblem Echoes:\\nShadows of Valentia": [
+        "AJJE",
+        "AJJJ",
+        "AJJK",
+        "AJJP"
+    ],
+    "Fire Emblem Fates\\nBirthright": [
+        "BFXE",
+        "BFXP"
+    ],
+    "Fire Emblem Fates\\nConquest": [
+        "BFYE",
+        "BFYP"
+    ],
+    "Fire Emblem Fates": [
+        "BFZE",
+        "BFZK",
+        "BFZP"
+    ],
+    "Fire Emblem if": [
+        "BFXZ"
+    ],
+    "Fire Emblem: Awakening": [
+        "AFEP"
+    ],
+    "Fish Eyes 3D": [
+        "ARFJ"
+    ],
+    "Flap Flap": [
+        "BFFP"
+    ],
+    "Fossil Fighters Frontier": [
+        "AHRD",
+        "AHRE"
+    ],
+    "Freakyforms Deluxe\\nYour Creations, Alive!": [
+        "ATQE",
+        "ATQP"
+    ],
+    "Frogger 3D": [
+        "AFRE",
+        "AFRJ",
+        "AFRP"
+    ],
+    "Funassy VS Dragons": [
+        "BF4J"
+    ],
+    "Funfair Party Games": [
+        "AFND",
+        "AFNP"
+    ],
+    "Funky Barn 3D": [
+        "AFME",
+        "AFMJ",
+        "AFMP"
+    ],
+    "Future Card Buddyfight\\nHead for BuddyChampion": [
+        "BFAJ"
+    ],
+    "Future Card Buddyfight\\nHereComes OurStrongestBud": [
+        "BFBJ"
+    ],
+    "Future Card Buddyfight\\nfriendship exploding figh": [
+        "BDYJ"
+    ],
+    "G1 Grand Prix": [
+        "AHTJ"
+    ],
+    "GAKI": [
+        "BDXJ"
+    ],
+    "GIRLS MODE 3\u3000\u30ad\u30e9\u30ad\u30e9\u2606\u30b3\u30fc\u30c7": [
+        "ECDJ"
+    ],
+    "GIRLS MODE\\n\u3088\u304f\u3070\u308a\u5ba3\u8a00\uff01\u3000\u30c8\u30ad\u30e1\u30adUP\uff01": [
+        "ACLJ"
+    ],
+    "GUDETAMA2:": [
+        "BGJJ"
+    ],
+    "GUDETAMA:": [
+        "BGLJ"
+    ],
+    "GUILD01": [
+        "AG9J"
+    ],
+    "GUNDAM THE 3D BATTLE": [
+        "A78J"
+    ],
+    "GYROZETTER\\nWings of Albaross": [
+        "ABCJ"
+    ],
+    "Gabrielle's Ghostly Groove 3D": [
+        "AG3E",
+        "AG3P"
+    ],
+    "Gaist Crusher God": [
+        "BGDJ"
+    ],
+    "Gaist Crusher": [
+        "AGYJ"
+    ],
+    "GameEhon_Adventure": [
+        "AY5J"
+    ],
+    "GameEhon_Princess": [
+        "AY4J"
+    ],
+    "Games Festival 1": [
+        "AAEP"
+    ],
+    "Games Festival 2": [
+        "AAFP"
+    ],
+    "Gardening Mama 2\\nForest Friends": [
+        "BGME"
+    ],
+    "Gardening Mama\\nMama and Her Forest Friends": [
+        "BGMJ"
+    ],
+    "Gardening mama\\nForest Friends": [
+        "BGMP"
+    ],
+    "Gardenscapes": [
+        "AG8P"
+    ],
+    "Garfield Kart": [
+        "AGPE",
+        "AGPP"
+    ],
+    "Gem Smashers": [
+        "AGSE"
+    ],
+    "Generator Rex:\\nAgent of Providence": [
+        "AGXE",
+        "AGXP"
+    ],
+    "Girls Mode 4\\n\u30b9\u30bf\u30fc\u2606\u30b9\u30bf\u30a4\u30ea\u30b9\u30c8": [
+        "AJBJ"
+    ],
+    "Girls' Fashion Shoot": [
+        "ANLD",
+        "ANLE",
+        "ANLP"
+    ],
+    "GirlsRPG CindereLife": [
+        "ACJJ"
+    ],
+    "Goosebumps: The Game": [
+        "BBME",
+        "BBMP"
+    ],
+    "Gravity Falls": [
+        "AGFE",
+        "AGFP"
+    ],
+    "Green Lantern\u2122\\nRise of the Manhunters": [
+        "AGLE",
+        "AGLP"
+    ],
+    "Gummy Bears\\nMagical Medallion": [
+        "AGVP"
+    ],
+    "HATSUNE MIKU\\nProject mirai 2": [
+        "AHNJ"
+    ],
+    "HATSUNE MIKU\\nProject mirai": [
+        "AM9J"
+    ],
+    "HEAVY FIRE\\nTHE CHOSEN FEW": [
+        "AHVJ"
+    ],
+    "HELLO KITTY 3D RACING": [
+        "BKYE",
+        "BKYP"
+    ],
+    "HYRULE WARRIORS LEGENDS": [
+        "BZHE",
+        "BZHJ",
+        "BZHP"
+    ],
+    "Hakuoki:\\nMemories of the Shinsengumi": [
+        "AH9P"
+    ],
+    "Hakuoki\\n~Memories of the Shinsengumi~": [
+        "AH9E"
+    ],
+    "Happy Feet 2": [
+        "AHFE",
+        "AHFP"
+    ],
+    "Harvest Moon:\\nA New Beginning": [
+        "ABQE",
+        "ABQP"
+    ],
+    "Harvest Moon:\\nSkytree Village": [
+        "AVAE",
+        "AVAP"
+    ],
+    "Harvest Moon:\\nThe Lost Valley": [
+        "AVME",
+        "AVMP"
+    ],
+    "Harvest Moon\\nThe Tale of Two Towns": [
+        "AT2E",
+        "AT2P"
+    ],
+    "Hatsune Miku:\\nProject Mirai DX": [
+        "BRXE",
+        "BRXP"
+    ],
+    "Hatsune Miku\\nProject Mirai DX": [
+        "BRXJ"
+    ],
+    "Heavy Fire:\\nThe Chosen Few 3D": [
+        "AHVP"
+    ],
+    "Heavy Fire:\\nThe Chosen Few": [
+        "AHVE"
+    ],
+    "Hello Kitty & Friends:\\nRockin' World Tour": [
+        "BKTJ",
+        "BKTP"
+    ],
+    "Hello Kitty & the Apron of Magic\\nRhythm Cooking\u266a": [
+        "BHKP"
+    ],
+    "Hello Kitty Picnic\\nwith Sanrio Characters": [
+        "AHLD"
+    ],
+    "Hello Kitty Picnic\\nwith Sanrio Friends": [
+        "AHLE"
+    ],
+    "Hello Kitty around the World": [
+        "AHKJ"
+    ],
+    "Hello Kitty\\nHappy Happy Family": [
+        "BHHP"
+    ],
+    "Heroes of Ruin": [
+        "AH6E",
+        "AH6P"
+    ],
+    "Hey! Pikmin": [
+        "BRCE",
+        "BRCJ",
+        "BRCP"
+    ],
+    "Hidden Expedition\\nTitanic": [
+        "AASP"
+    ],
+    "Hollywood Fame:\\nHidden Object Adventure": [
+        "AFXP"
+    ],
+    "Hometown Story": [
+        "AHXE",
+        "AHXJ",
+        "AHXP"
+    ],
+    "Horrid Henry: The Good,\\nThe Bad And The Bugly": [
+        "AHHP"
+    ],
+    "Horse Life 4": [
+        "BH4P"
+    ],
+    "Horse Vet 3D": [
+        "BP9P"
+    ],
+    "Horses 3D": [
+        "AHSE"
+    ],
+    "Hot Wheels\u2122 WBD": [
+        "AEAE",
+        "AEAP"
+    ],
+    "Hotel Transylvania": [
+        "AH8E",
+        "AH8F",
+        "AH8P"
+    ],
+    "How to Train Your Dragon 2": [
+        "BTDE",
+        "BTDP"
+    ],
+    "HyakumasuDorazan\\nNobitaNoTimeBattle": [
+        "BNHJ"
+    ],
+    "I Love My Cats": [
+        "ALKP"
+    ],
+    "I Love My Dogs": [
+        "ALWP"
+    ],
+    "I Love My Horse": [
+        "BMHP"
+    ],
+    "I Love My Little Boy": [
+        "BLBP"
+    ],
+    "I Love My Little Girl": [
+        "BLGP"
+    ],
+    "I Love My Pets": [
+        "AA6P"
+    ],
+    "I Love My Pony": [
+        "ALNP"
+    ],
+    "Ice Age\u2122 4\\nArctic Games": [
+        "AQLP"
+    ],
+    "Ice Age\u2122\\nArctic Games": [
+        "AQLE"
+    ],
+    "Il professor Layton\\ne la maschera dei miracoli": [
+        "AKKI"
+    ],
+    "Il professor Layton\\ne l\u2019eredit\u00e0 degli Aslant": [
+        "AL6I"
+    ],
+    "Imagine Champion Rider 3D": [
+        "AHSP"
+    ],
+    "Imagine\u00ae Collection": [
+        "BCLP"
+    ],
+    "Imagine\u00ae\\nbabyz\u00ae": [
+        "ABAE"
+    ],
+    "Imagine\u2122\\nBabies 3D": [
+        "ABAP"
+    ],
+    "Imagine\u2122\\nFashion Designer 3D": [
+        "AGUP"
+    ],
+    "Imagine\u2122\\nFashion Designer": [
+        "AGUE"
+    ],
+    "Imagine\u2122\\nFashion Life": [
+        "AF3E"
+    ],
+    "Imagine\u2122\\nFashion World 3D": [
+        "AF3P"
+    ],
+    "Inazuma Eleven 3\\nBomb Blast": [
+        "AXBP",
+        "AXBZ"
+    ],
+    "Inazuma Eleven 3\\nLightning Bolt": [
+        "AXSP",
+        "AXSZ"
+    ],
+    "Inazuma Eleven 3\\nTeam Ogre Attacks!": [
+        "AXGP",
+        "AXGZ"
+    ],
+    "Inazuma Eleven GO\\nChrono Stones: Thunderflash": [
+        "ARAP"
+    ],
+    "Inazuma Eleven GO\\nChrono Stones: Wildfire": [
+        "ANPP"
+    ],
+    "Inazuma Eleven GO\\nLight": [
+        "AE4P"
+    ],
+    "Inazuma Eleven GO\\nShadow": [
+        "AEDP"
+    ],
+    "IslandDays": [
+        "BDZJ"
+    ],
+    "JAWS: Ultimate Predator": [
+        "AJWE"
+    ],
+    "JS-Girl Doki Doki\\nModel Challenge": [
+        "BJSJ"
+    ],
+    "Jake Hunter\\nGHOST OF THE DUSK": [
+        "BG9E"
+    ],
+    "James Noir's Hollywood Crimes": [
+        "AHCE"
+    ],
+    "James Noir's\\nHollywood Crimes 3D": [
+        "AHCP"
+    ],
+    "Jet Dog": [
+        "AJTP"
+    ],
+    "Jewel Link Double Pack\\nAtlantic Quest / Safari Q": [
+        "BJLP"
+    ],
+    "Jewel Link\\nLegends of Atlantis": [
+        "AJ5P"
+    ],
+    "Jewel Master Atlantis 3D": [
+        "AJ5X"
+    ],
+    "Jewel Master\\nCradle of Egypt 2 3D": [
+        "AJEE",
+        "AJEF",
+        "AJEP"
+    ],
+    "Jewel Master\\nCradle of Rome 2": [
+        "AJLE",
+        "AJLP",
+        "AJLZ"
+    ],
+    "Jewel Match 3": [
+        "AJUP"
+    ],
+    "Jewel Quest Heritage": [
+        "AJ4P"
+    ],
+    "Jewel Quest Mysteries\\nThe Seventh Gate": [
+        "AJQP"
+    ],
+    "JewelPet 3DS": [
+        "AJPJ"
+    ],
+    "JewelQuest 6": [
+        "AJ6P"
+    ],
+    "Jewelpet 3DS 2": [
+        "AJYJ"
+    ],
+    "Jewelpet 3DS 6": [
+        "BJPJ"
+    ],
+    "Junior Classic Games": [
+        "AJCE"
+    ],
+    "Junior Games 3D": [
+        "AJCP"
+    ],
+    "KAWAII KONEKO 3D": [
+        "AKCJ"
+    ],
+    "KINGDOM HEARTS 3D\\n[Dream Drop Distance]": [
+        "AKHE",
+        "AKHJ",
+        "AKHP"
+    ],
+    "KOBITO GAME TAIZEN": [
+        "BK3J"
+    ],
+    "KOKUGA": [
+        "AK8J"
+    ],
+    "KONEKO NO ALBUM": [
+        "BLCJ"
+    ],
+    "KaiteoboeruDoragana": [
+        "BDAJ"
+    ],
+    "Kamiwazawanda\\nKirakiraichibangai Kikiippatsu!": [
+        "AWFJ"
+    ],
+    "Karous\\n- The Beast Of Re\uff1aEden -": [
+        "BKEJ"
+    ],
+    "KasekiHorider MugenGear": [
+        "AHRJ"
+    ],
+    "KenkaBancho6\\nsoul&blood": [
+        "BC6J"
+    ],
+    "Kid Icarus: Uprising": [
+        "AKDE",
+        "AKDJ",
+        "AKDP"
+    ],
+    "Kirby Battle Royale": [
+        "AJ8E",
+        "AJ8J",
+        "AJ8P"
+    ],
+    "Kirby's Extra Epic Yarn": [
+        "BE4E",
+        "BE4J",
+        "BE4P"
+    ],
+    "Kirby: Planet Robobot": [
+        "AT3A",
+        "AT3K"
+    ],
+    "Kirby: Triple Deluxe": [
+        "BALE",
+        "BALJ",
+        "BALK",
+        "BALP"
+    ],
+    "Konchu monster\\nsuper battle": [
+        "BUXJ"
+    ],
+    "Kumamon\u2605Bomber\\nPuzzle de Kumamontaisou": [
+        "BKMJ"
+    ],
+    "Kung Fu Panda: SLL": [
+        "BKFE",
+        "BKFP"
+    ],
+    "Kunio-kun nekketsu complete\\nfamicom edition": [
+        "BKCJ"
+    ],
+    "Kuniokun SP Ranto Kyosokyoku": [
+        "AK2J",
+        "AK2K"
+    ],
+    "Kuniokun Special": [
+        "AK9K"
+    ],
+    "LAYTON'S MYSTERY JOURNEY\\nKatrielle and the Milli": [
+        "BLFJ"
+    ],
+    "LAYTON'S MYSTERY JOURNEY\u2122\\nKatrielle and the Mill": [
+        "BLFE",
+        "BLFP"
+    ],
+    "LEGO\u00ae Batman\u2122 2:\\nDC Super Heroes": [
+        "ALBD",
+        "ALBE",
+        "ALBF",
+        "ALBP"
+    ],
+    "LEGO\u00ae Batman\u2122 3\\nBeyond Gotham": [
+        "BTME",
+        "BTMJ",
+        "BTMP",
+        "BTMV",
+        "BTMX",
+        "BTMY",
+        "BTMZ"
+    ],
+    "LEGO\u00ae City Undercover:\\nThe Chase Begins": [
+        "AA8E",
+        "AA8J",
+        "AA8P"
+    ],
+    "LEGO\u00ae Friends": [
+        "AZJE",
+        "AZJP"
+    ],
+    "LEGO\u00ae Harry Potter\u2122:\\nYears 5-7": [
+        "AHPE",
+        "AHPP"
+    ],
+    "LEGO\u00ae Jurassic World": [
+        "BLJJ"
+    ],
+    "LEGO\u00ae Jurassic World\u2122": [
+        "BLJE",
+        "BLJP",
+        "BLJV",
+        "BLJX",
+        "BLJY",
+        "BLJZ"
+    ],
+    "LEGO\u00ae Legends of Chima\u2122": [
+        "APRE",
+        "APRP"
+    ],
+    "LEGO\u00ae MARVEL's\\nAvengers": [
+        "ALEE",
+        "ALEJ",
+        "ALEP",
+        "ALEV",
+        "ALEX",
+        "ALEY",
+        "ALEZ"
+    ],
+    "LEGO\u00ae Marvel\u2122 Super Heroes\\nUniverse in Peril": [
+        "AL5D",
+        "AL5E",
+        "AL5F",
+        "AL5J",
+        "AL5P",
+        "AL5S",
+        "AL5Y"
+    ],
+    "LEGO\u00ae Ninjago\u2122:\\nShadow of Ronin": [
+        "BLSE"
+    ],
+    "LEGO\u00ae Ninjago\u2122\\nNindroids\u2122": [
+        "BLNE",
+        "BLNJ",
+        "BLNP",
+        "BLNX",
+        "BLNY",
+        "BLNZ"
+    ],
+    "LEGO\u00ae Pirates of the Caribbean\\nThe Video Game": [
+        "APCE",
+        "APCP"
+    ],
+    "LEGO\u00ae STAR WARS\u2122:\\nThe Force Awakens": [
+        "BLWD",
+        "BLWE",
+        "BLWF",
+        "BLWI",
+        "BLWJ",
+        "BLWP",
+        "BLWS"
+    ],
+    "LEGO\u00ae StarWars\u00ae III:\\nThe Clone Wars\u2122": [
+        "ALGE"
+    ],
+    "LEGO\u00ae StarWars\u2122 III:\\nThe Clone Wars\u2122": [
+        "ALGP"
+    ],
+    "LEGO\u00ae The Hobbit\u2122": [
+        "BLHE",
+        "BLHP",
+        "BLHX",
+        "BLHY",
+        "BLHZ"
+    ],
+    "LEGO\u00ae The Lord of the Rings\u2122": [
+        "ALAD",
+        "ALAE",
+        "ALAF",
+        "ALAP",
+        "ALAS"
+    ],
+    "LEGO\u00aeNinjago\u2122:\\nShadow of Ronin": [
+        "BLSJ",
+        "BLSP",
+        "BLSX",
+        "BLSY",
+        "BLSZ"
+    ],
+    "La Corda d'Oro3\\nFullvoice Special": [
+        "BC3J"
+    ],
+    "Lalaloopsy\u2122:\\nCarnival of Friends": [
+        "ALYE"
+    ],
+    "Langrisser Re:Incarnation\\n-TENSEI-": [
+        "BRGE"
+    ],
+    "Legend of Legacy": [
+        "BLLJ"
+    ],
+    "Legends Of Oz:\\nDorothy's Return": [
+        "BDTE",
+        "BDTP"
+    ],
+    "Let's Ride\\nBest in Breed 3D\u2122": [
+        "ALDE"
+    ],
+    "Life with Horses 3D": [
+        "BMGP"
+    ],
+    "Little Battlers eXperience": [
+        "ADNE",
+        "ADNP",
+        "ADNZ"
+    ],
+    "Lord of Magna: Maiden Heaven": [
+        "BKKE"
+    ],
+    "Lucky Luke & The Daltons": [
+        "ALJP"
+    ],
+    "Luigi's Mansion 2": [
+        "AGGP",
+        "AGGW"
+    ],
+    "Luigi's Mansion: Dark Moon": [
+        "AGGE"
+    ],
+    "Luigi's Mansion": [
+        "BGNE",
+        "BGNJ",
+        "BGNP"
+    ],
+    "Luv Me Buddies Wonderland": [
+        "BWLP"
+    ],
+    "Luxor": [
+        "ALXP"
+    ],
+    "L\u2019ERA GLACIALE\u2122 4\\nGIOCHI POLARI": [
+        "AQLI"
+    ],
+    "M & S at the London 2012\\nOlympic Games": [
+        "ACME",
+        "ACMK",
+        "ACMP"
+    ],
+    "M & S at the Rio 2016\\nOlympic Games": [
+        "BGXE",
+        "BGXJ",
+        "BGXP"
+    ],
+    "MAHJONG CUB3D": [
+        "ASHE"
+    ],
+    "MAJIN BONE": [
+        "BZRJ"
+    ],
+    "MARIO KART 7": [
+        "AMKE",
+        "AMKK",
+        "AMKP",
+        "AMKW"
+    ],
+    "MEDAROT7\\nKABUTO Ver.": [
+        "AQBJ"
+    ],
+    "MEDAROT7\\nKUWAGATA Ver.": [
+        "AQWJ"
+    ],
+    "MEDAROT8\\nKABUTO Ver.": [
+        "BMKJ"
+    ],
+    "MEDAROT8\\nKUWAGATA Ver.": [
+        "BMQJ"
+    ],
+    "MEDAROT9\\nKABUTO Ver.": [
+        "BA9J"
+    ],
+    "MEDAROT9\\nKUWAGATA Ver.": [
+        "BB9J"
+    ],
+    "METAL GEAR SOLID\\nSNAKE EATER 3D": [
+        "AMGE",
+        "AMGJ",
+        "AMGP"
+    ],
+    "METALMAX4\\nDiva of The Moonlight": [
+        "AX4J"
+    ],
+    "METROID PRIME\\nFEDERATION FORCE": [
+        "BCAE",
+        "BCAJ",
+        "BCAP"
+    ],
+    "METROID\\nSamus Returns": [
+        "A9AE",
+        "A9AJ",
+        "A9AP"
+    ],
+    "MIKE THE KNIGHT": [
+        "BMJP"
+    ],
+    "MOKOMOKO FRIENDS": [
+        "BM5J"
+    ],
+    "MONSTER HUNTER 3 (tri-) G": [
+        "AMHJ"
+    ],
+    "MONSTER HUNTER 3 ULTIMATE": [
+        "AMHE",
+        "AMHP"
+    ],
+    "MONSTER HUNTER 4 ULTIMATE": [
+        "BFGE",
+        "BFGP"
+    ],
+    "MONSTER HUNTER 4G": [
+        "BFGJ",
+        "BFGZ"
+    ],
+    "MONSTER HUNTER 4": [
+        "AH4J",
+        "AH4K",
+        "AH4Z"
+    ],
+    "MONSTER HUNTER STORIES": [
+        "AAHE",
+        "AAHJ",
+        "AAHP"
+    ],
+    "MONSTER HUNTER XX": [
+        "AGQJ"
+    ],
+    "MONSTER HUNTER X": [
+        "BXXJ"
+    ],
+    "MONSTER HUNTER\\nGENERATIONS": [
+        "BXXE",
+        "BXXP"
+    ],
+    "MYST": [
+        "AM7E",
+        "AM7P"
+    ],
+    "Madagascar 3": [
+        "AMCE",
+        "AMCJ",
+        "AMCP"
+    ],
+    "Madden NFL Football": [
+        "AMDE",
+        "AMDP"
+    ],
+    "Mahjong 3D\\nWarriors of the Emperor": [
+        "AMZE",
+        "AMZP"
+    ],
+    "Mahjong Mysteries\\nAncient Athena 3D": [
+        "AM5P"
+    ],
+    "Mahjongg Mysteries\\nAncient Athena 3D": [
+        "AM5Z"
+    ],
+    "Maple Story": [
+        "BMPJ",
+        "BMPK"
+    ],
+    "Mario & Luigi: Bowser's Inside\\nStory + Bowser Jr": [
+        "A3RE",
+        "A3RJ",
+        "A3RP"
+    ],
+    "Mario & Luigi: Paper Jam Bros.": [
+        "AYNP"
+    ],
+    "Mario & Luigi: Paper Jam": [
+        "AYNE",
+        "AYNJ"
+    ],
+    "Mario & Luigi: Superstar Saga\\n+ Bowser's Minions": [
+        "BRME",
+        "BRMJ",
+        "BRMP"
+    ],
+    "Mario & Luigi\\nDream Team Bros.": [
+        "AYMP"
+    ],
+    "Mario & Luigi\\nDream Team": [
+        "AYME"
+    ],
+    "Mario Golf: World Tour": [
+        "AJ3E",
+        "AJ3J",
+        "AJ3P"
+    ],
+    "Mario Party: Island Tour": [
+        "ATSE",
+        "ATSJ",
+        "ATSP"
+    ],
+    "Mario Party: Star Rush": [
+        "BAAE",
+        "BAAJ",
+        "BAAP"
+    ],
+    "Mario Party: The Top 100": [
+        "BHRE",
+        "BHRJ",
+        "BHRP"
+    ],
+    "Mario Sports Superstars": [
+        "AUNE",
+        "AUNJ",
+        "AUNP"
+    ],
+    "Mario Tennis Open": [
+        "AGAE",
+        "AGAJ",
+        "AGAP",
+        "AGAW"
+    ],
+    "Mario vs. Donkey Kong\\nTipping Stars": [
+        "JYLJ"
+    ],
+    "Mario&Luigi RPG4\\nDreamAdventure": [
+        "AYMJ"
+    ],
+    "Marvel Super Hero Squad\\nThe Infinity Gauntlet": [
+        "AMSE",
+        "AMSP"
+    ],
+    "Me & My Pets 3D": [
+        "BM3P"
+    ],
+    "Me & My furry Patients 3D": [
+        "BMTP"
+    ],
+    "Medarot DUAL\\nKABUTO Ver.": [
+        "AQVJ"
+    ],
+    "Medarot DUAL\\nKUWAGATA Ver.": [
+        "AQAJ"
+    ],
+    "Medarot Girls Mission\\nKABUTO Ver.": [
+        "BGPJ"
+    ],
+    "Medarot Girls Mission\\nKUWAGATA Ver.": [
+        "BGQJ"
+    ],
+    "Mega Man Legacy Collection": [
+        "BMME",
+        "BMMJ"
+    ],
+    "Mensa Academy": [
+        "AMMP"
+    ],
+    "Michael Jackson\\nThe Experience 3D": [
+        "AMJE",
+        "AMJP"
+    ],
+    "Miitopia": [
+        "ADQE",
+        "ADQJ",
+        "ADQP"
+    ],
+    "Moco Moco Friends": [
+        "BM5E"
+    ],
+    "Monster 4X4 3D": [
+        "AM4E",
+        "AM4P"
+    ],
+    "Monster High -\\nNew Ghoul in School": [
+        "BMSE",
+        "BMSP"
+    ],
+    "Monster High\u2122: 13 Wishes": [
+        "AEFP",
+        "AEFZ"
+    ],
+    "Monster High\u2122: 13 Wishes\u2122": [
+        "AEFE"
+    ],
+    "Monster High\u2122\\nSkultimate Roller Maze": [
+        "AH5P"
+    ],
+    "Monster High\u2122\\nSkultimate Roller Maze\u2122": [
+        "AH5E"
+    ],
+    "Moshi Monsters\u2122\\nKatsuma Unleashed": [
+        "ADME",
+        "ADMP"
+    ],
+    "Moshi Monsters\u2122\\nMoshlings\u2122 Theme Park": [
+        "AA9E",
+        "AA9P"
+    ],
+    "Movie Player": [
+        "AABP"
+    ],
+    "Murder on the Titanic": [
+        "AM8P"
+    ],
+    "Mushibugyo": [
+        "BMBJ"
+    ],
+    "My Baby Pet Hotel 3D": [
+        "AEYP"
+    ],
+    "My Exotic Farm": [
+        "ABUP"
+    ],
+    "My Farm 3D": [
+        "ANJP"
+    ],
+    "My Foal 3D": [
+        "AM3Z"
+    ],
+    "My Life on a farm 3D": [
+        "BHFP"
+    ],
+    "My Little Baby 3D": [
+        "AYYP"
+    ],
+    "My Melody": [
+        "BM7J"
+    ],
+    "My Pet Puppy 3D": [
+        "AMYE",
+        "APYJ"
+    ],
+    "My Pet School 3D": [
+        "BM6P"
+    ],
+    "My Vet Practice 3D\\nIn the country": [
+        "AERP"
+    ],
+    "My Western Horse 3D": [
+        "AZHP"
+    ],
+    "My Zoo Vet\\nPractice 3D": [
+        "ATXP"
+    ],
+    "Mystery Case Files:\\nDire Grove": [
+        "ADHP"
+    ],
+    "Mystery Case Files:\\nRavenhearst": [
+        "AAQP"
+    ],
+    "Mystery Case Files:\\nReturn to Ravenhearst": [
+        "AR2P"
+    ],
+    "Mystery Murders:\\nJack the Ripper": [
+        "AAJP"
+    ],
+    "NANO ASSAULT": [
+        "AN3J"
+    ],
+    "NARUTO Powerful Shippuden": [
+        "AN4E",
+        "AN4P"
+    ],
+    "NARUTO SHIPPUDEN 3D\\nThe New ERA": [
+        "ANTF",
+        "ANTP"
+    ],
+    "NARUTO-\u30ca\u30eb\u30c8- \u75be\u98a8\u4f1d\\n\u5fcd\u7acb\u4f53\u7d75\u5dfb\uff01\u6700\u5f37\u5fcd\u754c\u6c7a\u6226\uff01\uff01": [
+        "ANTJ"
+    ],
+    "NASCAR\u00ae Unleashed": [
+        "AC9E"
+    ],
+    "NCIS\u2122 3D\\nBASED ON THE TV SERIES": [
+        "ANCE",
+        "ANCP"
+    ],
+    "NEW\u30e9\u30d6\u30d7\u30e9\u30b9": [
+        "ALPJ"
+    ],
+    "NEW\u30e9\u30d6\u30d7\u30e9\u30b9\uff0b": [
+        "BLPJ"
+    ],
+    "Nano Assault": [
+        "AN3E"
+    ],
+    "Navy Commander": [
+        "BNCP"
+    ],
+    "Need For Speed\u2122 The Run": [
+        "ANSE",
+        "ANSJ",
+        "ANSP"
+    ],
+    "Nekketsu Monogatari Special": [
+        "BDJJ"
+    ],
+    "New Art Academy": [
+        "AACJ",
+        "AACP"
+    ],
+    "New Atelier Rorona\\nStory of the beginning": [
+        "BRAJ"
+    ],
+    "New SUPER MARIO BROS. 2": [
+        "ABEJ",
+        "ABEP",
+        "ABEW"
+    ],
+    "New Super Mario Bros. 2": [
+        "ABEE"
+    ],
+    "Nicktoons MLB\u00ae 3D": [
+        "ANKE"
+    ],
+    "Nikoli's Pencil Puzzle": [
+        "AS9E",
+        "AS9J"
+    ],
+    "Nintendo 3DS Guide: Louvre\\n(Deutsche Version)": [
+        "AL8D"
+    ],
+    "Nintendo 3DS Guide: Louvre\\n(English Version)": [
+        "AL8P"
+    ],
+    "Nintendo 3DS Guide: Louvre\\n(Version fran\u00e7aise)": [
+        "AL8F"
+    ],
+    "Nintendo 3DS Guide: Louvre\\n(Versione italiana)": [
+        "AL8I"
+    ],
+    "Nintendo 3DS Guide: Louvre\\n(versi\u00f3n en espa\u00f1ol)": [
+        "AL8S"
+    ],
+    "Nintendo 3DS Guide: Louvre": [
+        "AL8J",
+        "AL8K"
+    ],
+    "Nintendo Presents\\nNew Style Boutique 3": [
+        "AJBP"
+    ],
+    "Nintendo presents:\\nNew Style Boutique": [
+        "ACLP"
+    ],
+    "Nintendo presents\\nNew Style Boutique 2": [
+        "ECDP"
+    ],
+    "Nintendo presents\\nStyle Savvy: Fashion Forward": [
+        "ECDE"
+    ],
+    "Nobunaga's Ambition 2": [
+        "BNYJ"
+    ],
+    "Nobunaga's Ambition": [
+        "BNBJ"
+    ],
+    "ONE PIECE\\nROMANCE DAWN": [
+        "BRDP",
+        "BRDZ"
+    ],
+    "ONE PIECE\\nUNLIMITED WORLD R": [
+        "BUWJ"
+    ],
+    "ONE PIECE\\nUnlimited World Red": [
+        "BUWE",
+        "BUWP"
+    ],
+    "ONE PIECE\\n\u5927\u6d77\u8cca\u95d8\u6280\u5834": [
+        "BUZJ"
+    ],
+    "OSYARENA KOINU 3D": [
+        "AYUJ"
+    ],
+    "Ocha-Ken To Itsumo Nakayoshi": [
+        "AE3J"
+    ],
+    "One Piece\\nUnlimited Cruise SP 2": [
+        "AL9P"
+    ],
+    "One Piece\\nUnlimited Cruise SP": [
+        "ALFP"
+    ],
+    "Order Up!!": [
+        "AUPP"
+    ],
+    "Oregon Trail": [
+        "AT9E"
+    ],
+    "Oshaberi Usagi": [
+        "AUGJ"
+    ],
+    "Outback Pet\\nRescue 3D": [
+        "BM4P"
+    ],
+    "Outdoors Unleashed\\nAfrica 3D": [
+        "AFKP"
+    ],
+    "Oxford Reading Tree\\nFloppy's Phonics vol.1": [
+        "AFZJ"
+    ],
+    "Oxford Reading Tree\\nFloppy's Phonics vol.2": [
+        "AX2J"
+    ],
+    "Oxford Reading Tree\\nFloppy's Phonics vol.3": [
+        "AX3J"
+    ],
+    "PAC-MAN GHOSTLY ADV 2": [
+        "BPME",
+        "BPMJ",
+        "BPMP"
+    ],
+    "PAC-MAN PARTY 3D": [
+        "AP9E",
+        "AP9J",
+        "AP9P"
+    ],
+    "PAC-MAN\u2122\\nand the Ghostly Adventures": [
+        "AEJE",
+        "AEJJ",
+        "AEJP"
+    ],
+    "PAPER MARIO\\nSticker Star": [
+        "AG5E",
+        "AG5J",
+        "AG5K",
+        "AG5P",
+        "AG5W"
+    ],
+    "PERSONAQ2\\nNEW CINEMA LABYRINTH": [
+        "AQ2J"
+    ],
+    "PERSONAQ\\nSHADOW OF THE LABYRINTH": [
+        "AQQJ"
+    ],
+    "PES 2011 3D": [
+        "AEEI",
+        "AEEP"
+    ],
+    "PES 2012 3D": [
+        "AE2D",
+        "AE2I",
+        "AE2P"
+    ],
+    "PES 2013 3D": [
+        "AWTD",
+        "AWTI",
+        "AWTP"
+    ],
+    "POMPOMPURIN\\nKoroKoro Adventures": [
+        "BP6J"
+    ],
+    "POYOPOYO": [
+        "AP4J"
+    ],
+    "PROFESSIONAL BASEBALL SPIRITS 2011": [
+        "APSJ"
+    ],
+    "PROFESSOR LAYTON\\nVS ACE ATTORNEY": [
+        "AVSJ"
+    ],
+    "PROJECT CROSS ZONE 2 ": [
+        "BX2K"
+    ],
+    "PROJECT X ZONE 2\\nBRAVE NEW WORLD": [
+        "BX2J"
+    ],
+    "PROJECT X ZONE 2\\nORIGINAL GAME SOUND": [
+        "BXPJ"
+    ],
+    "PROJECT X ZONE 2": [
+        "BX2E",
+        "BX2P"
+    ],
+    "PROJECT X ZONE": [
+        "AXXJ"
+    ],
+    "PUZZLE & DRAGONS CROSS\\nDRAGON type": [
+        "BPVJ"
+    ],
+    "PUZZLE & DRAGONS CROSS\\nGOD type": [
+        "BPWJ"
+    ],
+    "PUZZLE & DRAGONS\\nSUPER MARIO BROS. EDITION": [
+        "AZMJ"
+    ],
+    "PUZZLE BOBBLE UNIVERSE": [
+        "ABBP"
+    ],
+    "Pac-Man & Galaga\\nDimensions": [
+        "APGE",
+        "APGJ",
+        "APGP"
+    ],
+    "Paddington:\\nAdventures in London": [
+        "BPLE",
+        "BPLP"
+    ],
+    "Paws & Claws\\nPampered Pets Resort 3D": [
+        "AP8E"
+    ],
+    "Pazuru": [
+        "BPZP"
+    ],
+    "Persona Q2\\nNew Cinema Labyrinth": [
+        "AQ2E",
+        "AQ2P"
+    ],
+    "Persona Q:\\nShadow of the Labyrinth": [
+        "AQQE",
+        "AQQP"
+    ],
+    "PersonaQ\\nShadow Of The Labyrinth": [
+        "AQQK"
+    ],
+    "Pet Zombies": [
+        "APZE"
+    ],
+    "Pets Resort 3D": [
+        "AP3P"
+    ],
+    "Petz Fantasy 3D": [
+        "APFE",
+        "APFP"
+    ],
+    "Petz\u00ae\\nBeach": [
+        "APIE",
+        "APIP"
+    ],
+    "Petz\u00ae\\nCountryside": [
+        "APOE",
+        "APOP"
+    ],
+    "Phineas & Ferb:\\nQuest For Cool Stuff": [
+        "AAWE",
+        "AAWP"
+    ],
+    "Phoenix Wright: Ace Attorney\\nSpirit of Justice": [
+        "BG6J"
+    ],
+    "Phonics Fun with Biff,\\nChip and Kipper vol.1": [
+        "AFZP"
+    ],
+    "Phonics Fun with Biff,\\nChip and Kipper vol.2": [
+        "AX2P"
+    ],
+    "Phonics Fun with Biff,\\nChip and Kipper vol.3": [
+        "AX3P"
+    ],
+    "Picross 3D: Round 2": [
+        "BBPP"
+    ],
+    "Pilotwings Resort": [
+        "AWAE",
+        "AWAJ",
+        "AWAP"
+    ],
+    "Pinball Hall of Fame:\\nThe Williams Collection 3D": [
+        "APBE",
+        "APBP"
+    ],
+    "Pippi Longstocking 3D": [
+        "APEP"
+    ],
+    "Pok\u00e9mon Alpha Sapphire": [
+        "ECLA"
+    ],
+    "Pok\u00e9mon Art Academy": [
+        "BPCE",
+        "BPCJ",
+        "BPCP"
+    ],
+    "Pok\u00e9mon Moon": [
+        "BNEA"
+    ],
+    "Pok\u00e9mon Mystery Dungeon\\nGates to Infinity": [
+        "APDE",
+        "APDP"
+    ],
+    "Pokemon Mystery Dungeon\\nMagna gate and infinity ": [
+        "APDJ"
+    ],
+    "Pok\u00e9mon Omega Ruby": [
+        "ECRA"
+    ],
+    "Pok\u00e9mon Rumble Blast": [
+        "ACCE"
+    ],
+    "Pok\u00e9mon Rumble World": [
+        "ECFA"
+    ],
+    "Pok\u00e9mon Sun": [
+        "BNDA"
+    ],
+    "Pok\u00e9mon Ultra Moon": [
+        "A2BA"
+    ],
+    "Pok\u00e9mon Ultra Sun": [
+        "A2AA"
+    ],
+    "Pok\u00e9mon X": [
+        "EKJA"
+    ],
+    "Pok\u00e9mon Y": [
+        "EK2A"
+    ],
+    "Pok\u00e9mon\\nSuper Mystery Dungeon": [
+        "BPXE",
+        "BPXJ",
+        "BPXP"
+    ],
+    "Poochy & Yoshi's Woolly World": [
+        "AJNE",
+        "AJNJ",
+        "AJNP"
+    ],
+    "Poptropica: Forgotten Islands": [
+        "BPFE"
+    ],
+    "Power Rangers\\nMegaforce": [
+        "AZBE",
+        "AZBP"
+    ],
+    "Power Rangers\\nSuper Megaforce": [
+        "BSSE",
+        "BSSP"
+    ],
+    "PriPri Chi-chan!!\\nPriPri Decoroom": [
+        "B2CJ"
+    ],
+    "Pro Evolution Soccer 2011 3D": [
+        "AEEE"
+    ],
+    "Pro Evolution Soccer 2012 3D": [
+        "AE2E"
+    ],
+    "Pro Evolution Soccer 2013 3D": [
+        "AWTE"
+    ],
+    "Professeur Layton\\net le masque des miracles": [
+        "AKKF"
+    ],
+    "Professeur Layton\\net l\u2019h\u00e9ritage des Aslantes": [
+        "AL6F"
+    ],
+    "Professional Baseball\\nFamista2011": [
+        "AFSJ"
+    ],
+    "Professor Layton vs\\nPhoenix Wright: Ace Attorney": [
+        "AVSE",
+        "AVSP",
+        "AVSZ"
+    ],
+    "Professor Layton\\nand the Azran Legacy": [
+        "AL6E",
+        "AL6P"
+    ],
+    "Professor Layton\\nand the Mask of Miracle": [
+        "AKKJ"
+    ],
+    "Professor Layton\\nand the Miracle Mask": [
+        "AKKE",
+        "AKKP"
+    ],
+    "Professor Layton\\nen de Erfenis van de Azran": [
+        "AL6H"
+    ],
+    "Professor Layton\\nen het Masker der Wonderen": [
+        "AKKH"
+    ],
+    "Professor Layton\\nund das Verm\u00e4chtnis von Aslant": [
+        "AL6D"
+    ],
+    "Professor Layton\\nund die Maske der Wunder": [
+        "AKKD"
+    ],
+    "Project X Zone": [
+        "AXXE",
+        "AXXP"
+    ],
+    "Puppies 3D": [
+        "ACTE"
+    ],
+    "Puppies World 3D": [
+        "ACTP"
+    ],
+    "Purr Pals Purrfection": [
+        "AP6E",
+        "AP6P"
+    ],
+    "Putty Squad": [
+        "AYZE",
+        "AYZP"
+    ],
+    "Puyopuyo Chronicle": [
+        "BPUJ"
+    ],
+    "Puyopuyo Tetris": [
+        "BPTJ"
+    ],
+    "Puzzle & Dragons Z +\\nSuper Mario Bros. Edition": [
+        "AZGE",
+        "AZGP"
+    ],
+    "Puzzler Brain Games": [
+        "AAGP"
+    ],
+    "Puzzler Mind Gym 3D": [
+        "APUE",
+        "APUP"
+    ],
+    "Puzzler World 2012 3D": [
+        "APWE",
+        "APWP"
+    ],
+    "Puzzler World 2013": [
+        "AZLE",
+        "AZLP"
+    ],
+    "RABBIDS 3D": [
+        "ARBP"
+    ],
+    "RABBIDS\\nTRAVEL IN TIME": [
+        "ARBE"
+    ],
+    "RAYMAN ORIGINS": [
+        "ARME",
+        "ARMJ",
+        "ARMP"
+    ],
+    "RESIDENT EVIL\u00ae\\nREVELATIONS": [
+        "ABRE"
+    ],
+    "RESIDENT EVIL\u00ae\\nTHE MERCENARIES 3D": [
+        "ABME"
+    ],
+    "RESIDENT EVIL\u2122\\nREVELATIONS": [
+        "ABRP"
+    ],
+    "RESIDENT EVIL\u2122\\nTHE MERCENARIES 3D": [
+        "ABMP"
+    ],
+    "RIDGE RACER 3D": [
+        "ARRE",
+        "ARRJ",
+        "ARRP"
+    ],
+    "RISE OF THE GUARDIANS": [
+        "ARGE",
+        "ARGP"
+    ],
+    "RPGMaker Fes": [
+        "BRPE",
+        "BRPJ",
+        "BRPP"
+    ],
+    "Rabbids\\nRumble": [
+        "AR5E",
+        "AR5P"
+    ],
+    "Rabbids\\nTravel In Time": [
+        "ARBJ"
+    ],
+    "Radiant Historia:\\nPerfect Chronology": [
+        "BRBE",
+        "BRBP"
+    ],
+    "Rayman 3D": [
+        "ARYE",
+        "ARYP"
+    ],
+    "Rayman and Rabbids\\n- Family Pack": [
+        "BRRP"
+    ],
+    "Real Heroes: FireFighter 3D": [
+        "ARHD",
+        "ARHE",
+        "ARHP"
+    ],
+    "Reel Fishing Paradise 3D": [
+        "ARFE",
+        "ARFP"
+    ],
+    "Regular Show\\nM&RI8BL": [
+        "AEBE",
+        "AEBP"
+    ],
+    "Return to PopoloCrois:\\nA STORY OF SEASONS Fairyt": [
+        "BPPE"
+    ],
+    "Rhythm Paradise Megamix": [
+        "BPJP"
+    ],
+    "Rhythm Thief\\n& the Emperor's Treasure": [
+        "ARTE",
+        "ARTJ",
+        "ARTP"
+    ],
+    "Ridge Racer 3D": [
+        "ARRJ"
+    ],
+    "Riding Stables 3D\\nJumping for the Team": [
+        "AAPP"
+    ],
+    "Riding Stables 3D\\nRivals in the Saddle": [
+        "AMUP"
+    ],
+    "Riding Star 3D": [
+        "ARSP"
+    ],
+    "Rilakkuma\\nnakayoshi collection": [
+        "BGYJ"
+    ],
+    "Rilu Rilu Fairilu\\nMy First Fairilu Magic\u266a": [
+        "AR8J"
+    ],
+    "River City: RIVAL SHOWDOWN": [
+        "BDJE"
+    ],
+    "River City: Tokyo Rumble": [
+        "AK2E"
+    ],
+    "Rodea the Sky Soldier": [
+        "AR6E",
+        "AR6J",
+        "AR6K",
+        "AR6P"
+    ],
+    "RollerCoaster Tycoon\u00ae 3D": [
+        "AC8E",
+        "AC8P"
+    ],
+    "Rune Factory 4": [
+        "AR4E"
+    ],
+    "RuneFactory4": [
+        "AR4J"
+    ],
+    "SAMURAI WARRIORS:\\nChronicles": [
+        "A66E",
+        "A66P"
+    ],
+    "SD GUNDAM\\nGGENERATION 3D": [
+        "AGJJ"
+    ],
+    "SEGA 3D Archives": [
+        "BFKJ"
+    ],
+    "SEGA 3D Classics Collection 2": [
+        "BF3J"
+    ],
+    "SEGA 3D Classics Collection": [
+        "AK3E",
+        "AK3J",
+        "AK3P"
+    ],
+    "SENRAN KAGURA 2 SHINKU": [
+        "BNUJ",
+        "BNUK"
+    ],
+    "SENRAN KAGURA 2:\\nDeep Crimson": [
+        "BNUE",
+        "BNUP"
+    ],
+    "SENRAN KAGURA Burst": [
+        "AVHJ",
+        "AVHP"
+    ],
+    "SENRAN KAGURA": [
+        "ABHJ"
+    ],
+    "SHIFTING WORLD \u767d\u3068\u9ed2\u306e\u8ff7\u5bae": [
+        "ASZJ"
+    ],
+    "SHOKUGEKI_NO_SOMA": [
+        "BYDJ"
+    ],
+    "SIMPLEseries for Nintendo 3DS\\nVol.1 THE MAHJONG": [
+        "AAUJ"
+    ],
+    "SIMPLE\uff7c\uff98\uff70\uff7d\uff9e for \uff86\uff9d\uff83\uff9d\uff84\uff9e\uff703DS\\nVol.2 THE\u5bc6\u5ba4\u304b\u3089\u306e\u8131\u51fa \uff71\uff70\uff76\uff72": [
+        "BYEJ"
+    ],
+    "SIMPLE\uff7c\uff98\uff70\uff7d\uff9e for \uff86\uff9d\uff83\uff9d\uff84\uff9e\uff703DS\\nVol.3 THE\u5bc6\u5ba4\u304b\u3089\u306e\u8131\u51fa \uff71\uff70\uff76\uff72": [
+        "BP3J"
+    ],
+    "SONIC GENERATIONS": [
+        "ASNE",
+        "ASNJ",
+        "ASNP"
+    ],
+    "SONIC LOST WORLD": [
+        "ARVE",
+        "ARVJ",
+        "ARVP"
+    ],
+    "SPEC\uff5e\u5e72\uff5e": [
+        "BSPJ"
+    ],
+    "STARFOX64 3D": [
+        "ANRJ",
+        "ANRW"
+    ],
+    "STELLA GLOW": [
+        "BS3E",
+        "BS3J",
+        "BS3P"
+    ],
+    "STORY OF SEASONS:\\nTrio of Towns": [
+        "BB3E",
+        "BB3P"
+    ],
+    "STORY OF SEASONS": [
+        "BTSE",
+        "BTSP"
+    ],
+    "SUDOKU\\n-The Puzzle Game Collection-": [
+        "AS9P"
+    ],
+    "SUPER MARIO 3D LAND": [
+        "AREE",
+        "AREJ",
+        "AREK",
+        "AREP",
+        "AREW",
+        "AREZ"
+    ],
+    "SUPER MONKEY BALL 3D": [
+        "ASME",
+        "ASMJ",
+        "ASMP"
+    ],
+    "SUPER STREET FIGHTER \u2163\\n3D EDITION": [
+        "ASSE",
+        "ASSJ",
+        "ASSP"
+    ],
+    "Safari Quest": [
+        "BSQP"
+    ],
+    "Sangokushi 2": [
+        "BSJJ"
+    ],
+    "Sayonara Umihara Kawase": [
+        "AUFJ"
+    ],
+    "Schlag den Raab\\nDas 2. Spiel": [
+        "AS2D"
+    ],
+    "Scooby-Doo! & Looney Tunes\\nCartoon Universe: Adv": [
+        "BCUE"
+    ],
+    "Scribblenauts Unlimited": [
+        "ASLE",
+        "ASLP",
+        "ASLX"
+    ],
+    "Scribblenauts Unmasked\\nA DC Comics Adventure": [
+        "AD6E",
+        "AD6P"
+    ],
+    "Secret Agent Files: Miami": [
+        "ASAP"
+    ],
+    "Secret Mysteries\\nIn London": [
+        "ASXP"
+    ],
+    "Secrets of the Titanic\\n1912-2012": [
+        "ASEP"
+    ],
+    "Sekaiju to Fushigi no Dungeon2": [
+        "BD5J"
+    ],
+    "Sekaiju to Fushigi no Dungeon": [
+        "BFDJ"
+    ],
+    "Shanghai Mahjong": [
+        "BSMP"
+    ],
+    "Shantae and the Pirate's Curse": [
+        "AJAE",
+        "AJAP",
+        "BP8J"
+    ],
+    "Sherlock Holmes:\\nthe Mystery of the Frozen City": [
+        "AHAJ",
+        "AHAP"
+    ],
+    "Shifting World": [
+        "ASZE",
+        "ASZP"
+    ],
+    "Shin Megami Tensei IV:\\nApocalypse": [
+        "BG4E",
+        "BG4P"
+    ],
+    "Shin Megami Tensei IV": [
+        "AMXE"
+    ],
+    "Shin Megami Tensei:\\nDevil Summoner: Soul Hackers": [
+        "AHQE",
+        "AHQP"
+    ],
+    "Shin Megami Tensei:\\nDevil Survivor Overclocked": [
+        "AMTE",
+        "AMTP"
+    ],
+    "Shin Megami Tensei:\\nStrange Journey Redux": [
+        "AJ9E",
+        "AJ9P"
+    ],
+    "Shin Megami Tensei\\nDEEP STRANGE JOURNEY": [
+        "AJ9J"
+    ],
+    "Shinobi\u2122 3D": [
+        "ASVJ"
+    ],
+    "Shinobi\u2122": [
+        "ASVE",
+        "ASVP"
+    ],
+    "Shovel Knight": [
+        "AKSE",
+        "AKSJ",
+        "AKSP"
+    ],
+    "Skylanders Giants\u2122": [
+        "AG6E",
+        "AG6P",
+        "AG6X"
+    ],
+    "Skylanders SWAP Force\u2122": [
+        "BSFE",
+        "BSFP"
+    ],
+    "Skylanders SuperChargers\u2122": [
+        "BL5P"
+    ],
+    "Skylanders Trap Team\u2122": [
+        "BS9E",
+        "BS9P"
+    ],
+    "Skylanders\u00ae SuperChargers": [
+        "BL5E"
+    ],
+    "Skylanders\\nSpyro's Adventure": [
+        "ASPE",
+        "ASPJ",
+        "ASPP"
+    ],
+    "Sonic & All-Stars Racing\\nTransformed": [
+        "ALLE",
+        "ALLP"
+    ],
+    "Sonic Boom:\\nFire & Ice": [
+        "BS6E",
+        "BS6P"
+    ],
+    "Sonic Boom:\\nShattered Crystal": [
+        "BSYE",
+        "BSYP"
+    ],
+    "Sonic Toon:\\nFire & Ice": [
+        "BS6J"
+    ],
+    "Sonic Toon:\\nIsland Adventure": [
+        "BSYJ"
+    ],
+    "Spider-Man\u2122: Edge of Time": [
+        "AS7E",
+        "AS7P"
+    ],
+    "Spider-Man\u2122:\\nAux fronti\u00e8res du temps": [
+        "AS7F"
+    ],
+    "Spirit Camera\\nThe Cursed Memoir": [
+        "ALCE",
+        "ALCP"
+    ],
+    "SpongeBob HeroPants": [
+        "BPNE",
+        "BPNP"
+    ],
+    "SpongeBob SquarePants:\\nPlankton's Robotic Reveng": [
+        "ANXE",
+        "ANXP"
+    ],
+    "SpongeBob SquigglePants": [
+        "ASGE",
+        "ASGP"
+    ],
+    "Sports Island 3D": [
+        "ADEP"
+    ],
+    "Spot The Differences!": [
+        "BDFP"
+    ],
+    "Spy Hunter\u2122": [
+        "AHEE",
+        "AHEP"
+    ],
+    "Star Fox 64 3D": [
+        "ANRE",
+        "ANRP"
+    ],
+    "Starry\u2606Sky\\n\uff5ein Autumn\uff5e 3D": [
+        "AX6J"
+    ],
+    "Starry\u2606Sky\\n\uff5ein Spring\uff5e 3D": [
+        "AAXJ"
+    ],
+    "Starry\u2606Sky\\n\uff5ein Summer\uff5e 3D": [
+        "AZPJ"
+    ],
+    "Starry\u2606Sky\\n\uff5ein Winter\uff5e 3D": [
+        "AX7J"
+    ],
+    "Steel Diver": [
+        "ASDE",
+        "ASDJ",
+        "ASDP"
+    ],
+    "Sternenschweif 3D\\nDas Geheimnis im Zauberwald": [
+        "BSCD"
+    ],
+    "Style Savvy: Trendsetters": [
+        "ACLE"
+    ],
+    "Sudoku + 7 other\\nComplex Puzzles by Nikoli": [
+        "ANQP"
+    ],
+    "Sudoku by NIKOLI 3D vol.2": [
+        "AZNJ"
+    ],
+    "Sudoku by NIKOLI 3D": [
+        "ANQJ"
+    ],
+    "Suichara\\nWelcome to the Sweets School!": [
+        "B2SJ"
+    ],
+    "Super Black Bass 3D": [
+        "ASBE",
+        "ASBP"
+    ],
+    "Super Mario Maker\\nfor Nintendo 3DS": [
+        "AJHE",
+        "AJHJ",
+        "AJHP"
+    ],
+    "Super Pok\u00e9mon Rumble": [
+        "ACCJ",
+        "ACCP"
+    ],
+    "Super Smash Bros.\\nfor Nintendo 3DS": [
+        "AXCE",
+        "AXCJ",
+        "AXCK",
+        "AXCP"
+    ],
+    "Survivor 3D\\nThe Ultimate Adventure": [
+        "AV2P"
+    ],
+    "Survivor\\nHeroes": [
+        "BSHP"
+    ],
+    "Sushi Striker\\nThe Way of Sushido": [
+        "AFWE",
+        "AFWJ",
+        "AFWP"
+    ],
+    "TALES OF THE ABYSS": [
+        "AABE",
+        "AABJ",
+        "AABP"
+    ],
+    "TEKKEN\u00ae 3D PRIME EDITION": [
+        "ATKE",
+        "ATKJ"
+    ],
+    "TEKKEN\u2122 3D PRIME EDITION": [
+        "ATKK",
+        "ATKP"
+    ],
+    "TENKAI KNIGHTS\u2122\\nBRAVE BATTLE": [
+        "BTKE",
+        "BTKP"
+    ],
+    "TERRAFORMARS": [
+        "BFMJ"
+    ],
+    "TETRIS\u00ae": [
+        "ATLJ"
+    ],
+    "THE CROODS": [
+        "AQRE",
+        "AQRP"
+    ],
+    "THEATRHYTHM FINAL FANTASY\\nCURTAIN CALL": [
+        "BTHE",
+        "BTHP"
+    ],
+    "THEATRHYTHM\\nFINAL FANTASY": [
+        "ATHE",
+        "ATHP"
+    ],
+    "THOMAS & FRIENDS": [
+        "BTBP"
+    ],
+    "TIME TRAVELERS": [
+        "ATRJ"
+    ],
+    "TOEIC\u00ae\u30c6\u30b9\u30c8\\n\u8d85\u901f\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
+        "ATEJ"
+    ],
+    "TORIKO GOURMEGABATTLE!": [
+        "BT5J"
+    ],
+    "TRANSFORMERS 3\\nStealth Force Edition 3D": [
+        "ATFP"
+    ],
+    "TRANSFORMERS\\nPRIME": [
+        "ATPE",
+        "ATPP"
+    ],
+    "TRANSFORMERS\\nRise of the Dark Spark": [
+        "AYEE",
+        "AYEP"
+    ],
+    "TURBO": [
+        "AANE",
+        "AANP"
+    ],
+    "TanoshikuOmoshiroku\\nKankenshogakusei": [
+        "A3KJ"
+    ],
+    "Teddy Together": [
+        "AKMP"
+    ],
+    "Teenage Mutant Ninja Turtles\u2122:\\nDanger of the Ooz": [
+        "BMUE",
+        "BMUP"
+    ],
+    "Teenage Mutant Ninja Turtles\u2122:\\nMaster Splinter's": [
+        "BTNE",
+        "BTNP"
+    ],
+    "Teenage Mutant Ninja Turtles\u2122": [
+        "ANYE",
+        "ANYP",
+        "BNTE",
+        "BTWP"
+    ],
+    "Terraria": [
+        "BTEE",
+        "BTEJ",
+        "BTEP"
+    ],
+    "Tetris\u00ae Axis": [
+        "ATLE"
+    ],
+    "Tetris\u00ae Ultimate": [
+        "BTLE",
+        "BTLP"
+    ],
+    "Tetris\u00ae": [
+        "ATLP"
+    ],
+    "The Adventures of Tintin\\nThe Secret of the Unico": [
+        "ATNE",
+        "ATNJ",
+        "ATNP"
+    ],
+    "The Alliance Alive": [
+        "AL4E"
+    ],
+    "The Amazing Spider-Man 2\u2122": [
+        "AXYE",
+        "AXYP"
+    ],
+    "The Amazing Spider-Man": [
+        "AS8D",
+        "AS8E",
+        "AS8P"
+    ],
+    "The Cake Shop 2.": [
+        "AWCJ"
+    ],
+    "The Cube": [
+        "ACZP"
+    ],
+    "The Hidden": [
+        "AHDE"
+    ],
+    "The Job's Themepark 2.": [
+        "AWKJ"
+    ],
+    "The LEGO\u00ae Movie\\nVideogame": [
+        "AFJD",
+        "AFJE",
+        "AFJF",
+        "AFJJ",
+        "AFJP",
+        "AFJS"
+    ],
+    "The Legend of Korra\u2122:\\nA New Era Begins": [
+        "BLDE"
+    ],
+    "The Legend of Legacy": [
+        "BLLE",
+        "BLLP"
+    ],
+    "The Legend of Zelda\\nA Link Between Worlds": [
+        "BZLE",
+        "BZLJ",
+        "BZLK",
+        "BZLP"
+    ],
+    "The Legend of Zelda\\nMajora's Mask 3D": [
+        "AJRE",
+        "AJRJ",
+        "AJRK",
+        "AJRP"
+    ],
+    "The Legend of Zelda\\nOcarina of Time 3D": [
+        "AQEE",
+        "AQEJ",
+        "AQEK",
+        "AQEP",
+        "AQEW"
+    ],
+    "The Legend of Zelda\\nTri Force Heroes": [
+        "EA3E",
+        "EA3J",
+        "EA3P",
+        "EA3Z"
+    ],
+    "The Mysterious Cities of Gold:\\nSecret Paths": [
+        "BMCP"
+    ],
+    "The Peanuts\u00ae Movie:\\nSnoopy's Grand Adventure": [
+        "BPEE",
+        "BPEP"
+    ],
+    "The Penguins of Madagascar": [
+        "BPGE",
+        "BPGP"
+    ],
+    "The SNACK WORLD\\nTREJARERS": [
+        "BWSJ"
+    ],
+    "The Sims\u2122 3 Pets": [
+        "AS4E",
+        "AS4J",
+        "AS4P"
+    ],
+    "The Sims\u2122 3": [
+        "AS3E",
+        "AS3J",
+        "AS3P"
+    ],
+    "The Trash Pack": [
+        "ATZE",
+        "ATZP"
+    ],
+    "The Whitakers present\\nMilton & Friends 3D": [
+        "AM3P"
+    ],
+    "Thor\u2122:\\nGod of Thunder": [
+        "AGTE",
+        "AGTP"
+    ],
+    "Tom Clancy's Ghost Recon\\nShadow Wars": [
+        "AGRE",
+        "AGRJ",
+        "AGRP"
+    ],
+    "Tom Clancy's Splinter Cell 3D": [
+        "ASCJ",
+        "ASCP",
+        "ASCZ"
+    ],
+    "Tomodachi Life": [
+        "EC6E",
+        "EC6K",
+        "EC6P"
+    ],
+    "Tongariboshi To Maho no Machi": [
+        "AVCJ"
+    ],
+    "Top Model 3D": [
+        "BT2P"
+    ],
+    "Top Trumps NBA All-Stars": [
+        "AN8E"
+    ],
+    "Toriko! Ultimate Survival.": [
+        "BTCJ"
+    ],
+    "Touch!DoublePenSports": [
+        "APPJ"
+    ],
+    "Transformers\u2122 3\\nStealth Force Edition 3D": [
+        "ATFE"
+    ],
+    "Travel Adventures\\nwith Hello Kitty": [
+        "AHKE"
+    ],
+    "ULTIMATE NES REMIX": [
+        "BFRP"
+    ],
+    "Ultimate NES Remix": [
+        "BFRE",
+        "BFRJ"
+    ],
+    "Ultra baseball\\nAction card battle": [
+        "BUBJ"
+    ],
+    "Viking Invasion 2\\nTower Defense": [
+        "AVKP"
+    ],
+    "Virtue's Last Reward": [
+        "AKGP"
+    ],
+    "VitaminX\\nEvolution Plus": [
+        "BVXJ"
+    ],
+    "VitaminZ\\nRevolution": [
+        "BVZJ"
+    ],
+    "WORLD SOCCER\\nWinning Eleven 2012": [
+        "AE2J"
+    ],
+    "WORLD SOCCER\\nWinning Eleven 2013": [
+        "AWTJ"
+    ],
+    "WORLD SOCCER\\nWinning Eleven 2014 JE": [
+        "BSBJ"
+    ],
+    "WORLD SOCCER\\nWinning Eleven 2014": [
+        "BW4J"
+    ],
+    "WRC The Official Game": [
+        "BWRP"
+    ],
+    "WWE All Stars": [
+        "AWEE",
+        "AWEP"
+    ],
+    "WarioWare Gold": [
+        "AWXA"
+    ],
+    "Winning Eleven 3DSoccer": [
+        "AEEJ"
+    ],
+    "Winter Sports 2012\\nFeel the Spirit": [
+        "AWSP"
+    ],
+    "Winx Club: Saving Alfea": [
+        "BWCE",
+        "BWCP"
+    ],
+    "Wipeout 2": [
+        "AWPE"
+    ],
+    "Wipeout 3": [
+        "AW3E"
+    ],
+    "Wipeout Create & Crash": [
+        "AY8E"
+    ],
+    "Word Wizard 3D": [
+        "AWWP"
+    ],
+    "YO-KAI SANGOKUSHI": [
+        "AYKJ"
+    ],
+    "YO-KAI WATCH 2:\\nBONY SPIRITS": [
+        "BYGP"
+    ],
+    "YO-KAI WATCH 2:\\nFLESHY SOULS": [
+        "BYHP"
+    ],
+    "YO-KAI WATCH 2:\\nPSYCHIC SPECTERS": [
+        "BYSE",
+        "BYSP",
+        "BYSZ"
+    ],
+    "YO-KAI WATCH BLASTERS\\nRED CAT CORPS": [
+        "BYAE",
+        "BYAP"
+    ],
+    "YO-KAI WATCH BLASTERS\\nWHITE DOG SQUAD": [
+        "BYBE",
+        "BYBP"
+    ],
+    "YO-KAI WATCH BUSTERS 2\\nMAGNUM": [
+        "BYMJ"
+    ],
+    "YO-KAI WATCH BUSTERS 2\\nSWORD": [
+        "BYNJ"
+    ],
+    "YO-KAI WATCH": [
+        "AYWE",
+        "AYWK",
+        "AYWP",
+        "AYWZ"
+    ],
+    "YOSHI'S New ISLAND": [
+        "ATAE",
+        "ATAJ",
+        "ATAP",
+        "ATAZ"
+    ],
+    "Yakari": [
+        "AYRP"
+    ],
+    "Yo-kai Watch 2 Bony Spirits": [
+        "BYGE",
+        "BYGZ"
+    ],
+    "Yo-kai Watch 2 Fleshy Souls": [
+        "BYHE",
+        "BYHZ"
+    ],
+    "Yo-kai Watch 3": [
+        "ALZD",
+        "ALZE",
+        "ALZF",
+        "ALZI",
+        "ALZP",
+        "ALZS"
+    ],
+    "Yokai Watch 2 ganso": [
+        "BYGJ"
+    ],
+    "Yokai Watch 2 honke": [
+        "BYHJ"
+    ],
+    "Yokai Watch 2 shinuchi": [
+        "BYSJ"
+    ],
+    "Yokai Watch 3 SUKIYAKI": [
+        "ALZJ"
+    ],
+    "Yokai Watch 3 SUSHI": [
+        "BY3J"
+    ],
+    "Yokai Watch 3 TEMPURA": [
+        "BY4J"
+    ],
+    "Yokai Watch Busters\\nAkaneko Dan": [
+        "BYAJ"
+    ],
+    "Yokai Watch Busters\\nShiroinu Tai": [
+        "BYBJ"
+    ],
+    "Yokai Watch": [
+        "AYWJ"
+    ],
+    "Young Justice\u2122: Legacy": [
+        "AYJE"
+    ],
+    "Yu-Gi-Oh! ZEXAL\\nWorld Duel Carnival": [
+        "AYXP"
+    ],
+    "Yu-Gi-Oh!ZEXAL": [
+        "AYXJ"
+    ],
+    "ZERO ESCAPE": [
+        "BZGJ"
+    ],
+    "ZETSUBO YOSAI\\nescape adventure": [
+        "AZUJ"
+    ],
+    "ZOO MANIA\\nBUILD YOUR DREAM ZOO": [
+        "ANMJ"
+    ],
+    "ZOO RESORT": [
+        "AZOE",
+        "AZOP"
+    ],
+    "Zero Escape:\\nVirtue's Last Reward": [
+        "AKGE"
+    ],
+    "Zero Escape:\\nZero Time Dilemma": [
+        "BZEE"
+    ],
+    "aikatsu!my two princesses": [
+        "BAKJ"
+    ],
+    "atelier deco la doll\\ncollection": [
+        "AULJ"
+    ],
+    "attack on titan 2\\nfuture": [
+        "AKPJ"
+    ],
+    "attack on titan\\nchain": [
+        "BG2J"
+    ],
+    "attack on titan": [
+        "BGAJ"
+    ],
+    "beybladeburstgod": [
+        "BVBJ"
+    ],
+    "beybladeburst": [
+        "BUTJ"
+    ],
+    "cooking mama 4:Kitchen Magic": [
+        "ACQE"
+    ],
+    "cooking mama 4": [
+        "ACQP"
+    ],
+    "doodle jump adventures": [
+        "AEGE",
+        "AEGP",
+        "AEGZ"
+    ],
+    "hoppechan minnadeodekake!\\nwakuwaku hoppeland!!": [
+        "BH2J"
+    ],
+    "hoppechan tukutte!\\nasonde! punipunitown!!": [
+        "BHPJ"
+    ],
+    "hoppechan\\npunittoshibotte daibouken!": [
+        "BH3J"
+    ],
+    "kekiyasan monogatari\\noishiisuituwotukurou": [
+        "BC8J"
+    ],
+    "kinkinomaguna": [
+        "BKKJ"
+    ],
+    "kouenji joshi soccer 3\\nkoisuruirebun itukaha hea": [
+        "BKJJ"
+    ],
+    "kuniokun special": [
+        "AK9J"
+    ],
+    "minna no ennichi": [
+        "AENJ"
+    ],
+    "nicopuchi": [
+        "BNPJ"
+    ],
+    "nintendogs + cats": [
+        "ADAE",
+        "ADAJ",
+        "ADAP",
+        "ADAW",
+        "ADBE",
+        "ADBJ",
+        "ADBP",
+        "ADBW",
+        "ADCE",
+        "ADCJ",
+        "ADCP",
+        "ADCW"
+    ],
+    "pikapika nurse story2": [
+        "ANAJ"
+    ],
+    "pikapikanasumonogatari\\nsyounikahaitumooosawagi": [
+        "AG4J"
+    ],
+    "sumikkogurasi\\nkoko,dokonandesu?": [
+        "AWHJ"
+    ],
+    "sumikkogurasi\\nkokogaochitukunndesu": [
+        "BCNJ"
+    ],
+    "sumikkogurasi\\nmurawotukurunndesu": [
+        "BVSJ"
+    ],
+    "sumikkogurasi\\nomisehazimerundesu": [
+        "BSVJ"
+    ],
+    "the Smurfs\u2122": [
+        "BUSE",
+        "BUSP"
+    ],
+    "wan-nyan hospital2": [
+        "AWNJ"
+    ],
+    "wannyan petshop": [
+        "BWNJ"
+    ],
+    "wannyandoubutsubyouin\\npettonooisyasanninarou": [
+        "BW2J"
+    ],
+    "wannyandoubutsubyouin\\nsutekinajyuuisanninarou": [
+        "AWJJ"
+    ],
+    "\u719f\u8a9e \u901f\u5f15\u8f9e\u5178": [
+        "AJXJ"
+    ],
+    "\u30de\u30ae\\n\u65b0\u305f\u306a\u308b\u4e16\u754c": [
+        "BNWJ"
+    ],
+    "\u30de\u30ae\\n\u306f\u3058\u307e\u308a\u306e\u8ff7\u5bae": [
+        "ALMJ"
+    ],
+    "\u30b4\u30f3\\n\u30d0\u30af\u30d0\u30af\u30d0\u30af\u30d0\u30af\u30a2\u30c9\u30d9\u30f3\u30c1\u30e3\u30fc": [
+        "AG7J"
+    ],
+    "\u96f7\u5b50": [
+        "BRSJ"
+    ],
+    "\u8584\u685c\u9b3c 3D": [
+        "AH9J"
+    ],
+    "\u30c8\u30ea\u30b3 \u30b0\u30eb\u30e1\u30e2\u30f3\u30b9\u30bf\u30fc\u30ba\uff01": [
+        "AT6J"
+    ],
+    "\u85e4\u5b50\u30fbF\u30fb\u4e0d\u4e8c\u96c4\u30ad\u30e3\u30e9\u30af\u30bf\u30fc\u30ba\\n\u5927\u96c6\u5408\uff01SF\u30c9\u30bf\u30d0\u30bf\u30d1\u30fc\u30c6\u30a3\u30fc\uff01\uff01": [
+        "BFPJ"
+    ],
+    "\u8b0e\u60d1\u9928\\n\u97f3\u306e\u9593\u306b\u9593\u306b": [
+        "ANWJ"
+    ],
+    "\u4e09\u570b\u5fd7": [
+        "BGKJ"
+    ],
+    "\u6226\u56fd\u7121\u53cc Chronicle \uff13": [
+        "BC4J"
+    ],
+    "\u9b54\u754c\u738b\u5b50 devils and realist\\n\u4ee3\u7406\u738b\u306e\u79d8\u5b9d": [
+        "BDPJ"
+    ],
+    "\u30c6\u30a4\u30eb\u30ba \u30aa\u30d6 \u30b6 \u30ef\u30fc\u30eb\u30c9\\n\u30ec\u30fc\u30f4 \u30e6\u30ca\u30a4\u30c6\u30a3\u30a2": [
+        "ATUJ"
+    ],
+    "\u30d7\u30ed\u91ce\u7403 \u30d5\u30a1\u30df\u30b9\u30bf \u30ea\u30bf\u30fc\u30f3\u30ba": [
+        "BP5J"
+    ],
+    "\u30d7\u30ed\u91ce\u7403 \u30d5\u30a1\u30df\u30b9\u30bf \u30af\u30e9\u30a4\u30de\u30c3\u30af\u30b9": [
+        "BYFJ"
+    ],
+    "\u6697\u6bba\u6559\u5ba4 \u30a2\u30b5\u30b7\u30f3\u80b2\u6210\u8a08\u753b!!": [
+        "BA2J"
+    ],
+    "\u30ad\u30e9\u30e1\u30ad \u308f\u304f\u308f\u304f\u30b9\u30a4\u30fc\u30c4": [
+        "BSWJ"
+    ],
+    "\u6697\u6bba\u6559\u5ba4 \u6bba\u305b\u3093\u305b\u30fc\u5927\u5305\u56f2\u7db2!!": [
+        "BKLJ"
+    ],
+    "\u9006\u8ee2\u88c1\u5224123\u3000\u6210\u6b69\u5802\u30bb\u30ec\u30af\u30b7\u30e7\u30f3": [
+        "BHDJ"
+    ],
+    "\u6975\u9650\u8131\u51faADV\\n\u5584\u4eba\u30b7\u30dc\u30a6\u30c7\u30b9": [
+        "AKGJ"
+    ],
+    "\u30cf\u30de\u30c8\u30e9\\nLook at Smoking World": [
+        "BATJ"
+    ],
+    "\u307e\u3081\u30b4\u30de\\n\u3088\u3044\u3053 \u307e\u308b\u3044\u3053 \u3052\u3093\u304d\u306a\u3053\uff01": [
+        "AM6J"
+    ],
+    "\u30d7\u30ea\u30d1\u30e9\\n\u3081\u3056\u3081\u3088!\u5973\u795e\u306e\uff84\uff9e\uff9a\uff7d\uff83\uff9e\uff7b\uff9e\uff72\uff9d": [
+        "BP7J"
+    ],
+    "\u7267\u5834\u7269\u8a9e\\n\u3075\u305f\u3054\u306e\u6751\uff0b": [
+        "A22J"
+    ],
+    "\u7267\u5834\u7269\u8a9e\\n\u306f\u3058\u307e\u308a\u306e\u5927\u5730": [
+        "ABQJ"
+    ],
+    "\u7267\u5834\u7269\u8a9e\\n\u3064\u306a\u304c\u308b\u65b0\u5929\u5730": [
+        "BTSJ"
+    ],
+    "\u30c9\u30e9\u304b\u305a\\n\u306e\u3073\u592a\u306e\u3059\u3046\u3058\u5927\u5192\u967a": [
+        "ADWJ"
+    ],
+    "\u7267\u5834\u7269\u8a9e\\n\uff13\u3064\u306e\u91cc\u306e\u5927\u5207\u306a\u53cb\u3060\u3061": [
+        "BB3J"
+    ],
+    "\u307e\u3081\u30b4\u30de\\n\u306f\u3063\u3074\u30fc\uff01\u30b9\u30a4\u30fc\u30c4\u30d5\u30a1\u30fc\u30e0": [
+        "AGWJ"
+    ],
+    "\u307e\u307b\u30b3\u30ec\\n\u9b54\u6cd5\u2606\u3042\u3044\u3069\u308b\u30b3\u30ec\u30af\u30b7\u30e7\u30f3": [
+        "BM8J"
+    ],
+    "\u30d7\u30ea\u30d1\u30e9\\n\u3081\u3056\u305b\uff01\uff71\uff72\uff84\uff9e\uff99\u2606\uff78\uff9e\uff97\uff9d\uff8c\uff9f\uff98No.1\uff01": [
+        "APJJ"
+    ],
+    "\u307e\u3081\u3057\u3070": [
+        "AMEJ"
+    ],
+    "\u30bd\u30cb\u30d7\u30ed": [
+        "BS2J"
+    ],
+    "\u95d8\u795e\u90fd\u5e02": [
+        "BTTJ"
+    ],
+    "\u30c7\u30a3\u30ba\u30cb\u30fc\u00a0\u30a8\u30d4\u30c3\u30af\u30df\u30c3\u30ad\u30fc\uff1a\\n\u30df\u30c3\u30ad\u30fc\u306e\u3075\u3057\u304e\u306a\u5192\u967a": [
+        "AECJ"
+    ],
+    "\u5927\u9006\u8ee2\u88c1\u5224 -\u6210\u6b69\u5802\u9f8d\u30ce\u4ecb\u306e\u5192\u96aa-": [
+        "BDGJ"
+    ],
+    "\u30ef\u30f3\u30d4\u30fc\u30b9 ROMANCE DAWN\\n\u5192\u967a\u306e\u591c\u660e\u3051": [
+        "BRDJ"
+    ],
+    "\u592a\u9f13\u306e\u9054\u4eba \u30c9\u30b3\u30c9\u30f3\uff01\\n\u30df\u30b9\u30c6\u30ea\u30fc\u30a2\u30c9\u30d9\u30f3\u30c1\u30e3\u30fc": [
+        "BT8J"
+    ],
+    "\u8d85\u30fb\u6226\u95d8\u4e2d \u7a76\u6975\u306e\u5fcd\u3068\\n\u30d0\u30c8\u30eb\u30d7\u30ec\u30a4\u30e4\u30fc\u9802\u4e0a\u6c7a\u6226\uff01": [
+        "AJSJ"
+    ],
+    "\u30e1\u30c0\u30ed\u30c3\u30c8 \u30af\u30e9\u30b7\u30c3\u30af\u30b9\\n\u30ab\u30d6\u30c8Ver.": [
+        "BKUJ"
+    ],
+    "\u30e1\u30c0\u30ed\u30c3\u30c8 \u30af\u30e9\u30b7\u30c3\u30af\u30b9\\n\u30af\u30ef\u30ac\u30bfVer.": [
+        "BKWJ"
+    ],
+    "\u30ea\u30ba\u30e0\u5929\u56fd \u30b6\u30fb\u30d9\u30b9\u30c8\uff0b": [
+        "BPJJ"
+    ],
+    "\u5f31\u866b\u30da\u30c0\u30eb \u660e\u65e5\u3078\u306e\u9ad8\u56de\u8ee2": [
+        "AYPJ"
+    ],
+    "\u30c9\u30e9\u3048\u3082\u3093 \u306e\u3073\u592a\u3068\u5947\u8de1\u306e\u5cf6\\n\uff5e\u30a2\u30cb\u30de\u30eb \u30a2\u30c9\u30d9\u30f3\u30c1\u30e3\u30fc\uff5e": [
+        "AA2J"
+    ],
+    "\u30ad\u30e9\u2605\u30e1\u30ad \u304a\u3057\u3083\u308c\u30b5\u30ed\u30f3\uff01\\n\uff5e\u308f\u305f\u3057\u306e\u3057\u3054\u3068\u306f\u7f8e\u5bb9\u5e2b\u3055\u3093\uff5e": [
+        "AATJ"
+    ],
+    "\u5fc3\u970a\u30ab\u30e1\u30e9 \uff5e\u6191\u3044\u3066\u308b\u624b\u5e33\uff5e": [
+        "ALCJ"
+    ],
+    "\u30c9\u30e9\u3048\u3082\u3093 \u65b0\u30fb\u306e\u3073\u592a\u306e\u5927\u9b54\u5883\\n\uff5e\u30da\u30b3\u3068\uff15\u4eba\u306e\u63a2\u691c\u968a\uff5e": [
+        "BNMJ"
+    ],
+    "\u30c9\u30e9\u3048\u3082\u3093 \u65b0\u30fb\u306e\u3073\u592a\u306e\u65e5\u672c\u8a95\u751f": [
+        "BNNJ"
+    ],
+    "\u30cf\u30a4\u30ad\u30e5\u30fc!! Cross team match\uff01": [
+        "BHTJ"
+    ],
+    "\u30cf\u30a4\u30ad\u30e5\u30fc!! \u7e4b\u3052!\u9802\u306e\u666f\u8272!!": [
+        "BHQJ"
+    ],
+    "\u6d1e\u7a9f\u7269\u8a9e\uff13D": [
+        "ACVJ"
+    ],
+    "\u30a2\u30a4\u30ab\u30c4\uff01\\n365\u65e5\u306e\u30a2\u30a4\u30c9\u30eb\u30c7\u30a4\u30ba": [
+        "BA3J"
+    ],
+    "\u30a2\u30a4\u30ab\u30c4\uff01\\nMy No.1 Stage!": [
+        "AK4J"
+    ],
+    "\u4e03\u3064\u306e\u5927\u7f6a\\n\u771f\u5b9f\u306e\u51a4\u7f6a": [
+        "BS7J"
+    ],
+    "\u30c9\u30e9\u3048\u3082\u3093\\n\u306e\u3073\u592a\u306e\u5b9d\u5cf6": [
+        "BNLJ"
+    ],
+    "\u30d1\u30ba\u30c9\u30e9\uff3a\\n\u9650\u5b9a\u30c1\u30e3\u30ec\u30f3\u30b8\u7248": [
+        "APZJ"
+    ],
+    "\u30ef\u30f3\u30d4\u30fc\u30b9\\n\u8d85\u30b0\u30e9\u30f3\u30c9\u30d0\u30c8\u30eb\uff01\uff38": [
+        "BG3J"
+    ],
+    "\u592a\u9f13\u306e\u9054\u4eba\\n\u3069\u3093\u3068\u304b\u3064\u306e\u6642\u7a7a\u5927\u5192\u967a": [
+        "BT7J"
+    ],
+    "\u30c9\u30e9\u3048\u3082\u3093\\n\u306e\u3073\u592a\u306e\u3072\u307f\u3064\u9053\u5177\u535a\u7269\u9928": [
+        "AD9J"
+    ],
+    "\u30ef\u30f3\u30d4\u30fc\u30b9\\n\u30a2\u30f3\u30ea\u30df\u30c6\u30c3\u30c9\u30af\u30eb\u30fc\u30ba\uff33\uff30": [
+        "ALFJ"
+    ],
+    "\u30d1\u30ba\u30c9\u30e9\uff3a\\n\u30b3\u30ed\u30b3\u30ed\u30b3\u30df\u30c3\u30af\u9650\u5b9a\u4f53\u9a13\u7248": [
+        "ANFJ"
+    ],
+    "\u30c9\u30e9\u3048\u3082\u3093\\n\u306e\u3073\u592a\u306e\u5357\u6975\u30ab\u30c1\u30b3\u30c1\u5927\u5192\u967a": [
+        "BDUJ"
+    ],
+    "\u8d85\u30fb\u9003\u8d70\u4e2d\\n\u3042\u3064\u307e\u308c\uff01\u6700\u5f37\u306e\u9003\u8d70\u8005\u305f\u3061": [
+        "BTUJ"
+    ],
+    "\u592a\u9f13\u306e\u9054\u4eba\\n\u3061\u3073\u30c9\u30e9\u30b4\u30f3\u3068\u4e0d\u601d\u8b70\u306a\u30aa\u30fc\u30d6": [
+        "ATDJ"
+    ],
+    "\u3054\u5f53\u5730\u9244\u9053\\n\uff5e\u3054\u5f53\u5730\u30ad\u30e3\u30e9\u3068\u65e5\u672c\u5168\u56fd\u306e\u65c5\uff5e": [
+        "BLTJ"
+    ],
+    "\u30cd\u30b3\u30fb\u30c8\u30e2\\n\u307b\u3093\u308f\u304b\u5bb6\u65cf\u304c\u3067\u304d\u3061\u3083\u3046\u30b2\u30fc\u30e0": [
+        "BNFJ"
+    ],
+    "\u9006\u8ee2\u88c1\u5224\uff15": [
+        "AGKJ"
+    ],
+    "\u30af\u30de\u30fb\u30c8\u30e2": [
+        "AKMJ"
+    ],
+    "\u30d1\u30ba\u30c9\u30e9\uff3a": [
+        "AZGJ"
+    ],
+    "\u30b7\u30a2\u30c8\u30ea\u30ba\u30e0 FF \u30ab\u30fc\u30c6\u30f3\u30b3\u30fc\u30eb": [
+        "BTHJ"
+    ],
+    "\u304a\u3055\u308f\u308a\u63a2\u5075 \u5c0f\u6ca2\u91cc\u5948 \u30e9\u30a4\u30b8\u30f3\u30b0\uff13\\n\u306a\u3081\u3053\u306f\u30d0\u30ca\u30ca\u306e\u5922\u3092\u898b\u308b\u304b\uff1f": [
+        "AN7J"
+    ],
+    "\u30cf\u30b3\u30dc\u30fc\u30a4\uff01 \u30cf\u30b3\u3065\u3081\uff22\uff2f\uff38": [
+        "BC2J"
+    ],
+    "\u4eee\u9762\u30e9\u30a4\u30c0\u30fc \u30c8\u30e9\u30d9\u30e9\u30fc\u30ba\u6226\u8a18": [
+        "AXAJ"
+    ],
+    "\u30b7\u30a2\u30c8\u30ea\u30ba\u30e0 \u30c9\u30e9\u30b4\u30f3\u30af\u30a8\u30b9\u30c8": [
+        "BTQJ"
+    ],
+    "\uff2e\uff21\uff32\uff35\uff34\uff2f \uff33\uff24\u30d1\u30ef\u30d5\u30eb\u75be\u98a8\u4f1d": [
+        "AN4J",
+        "AN4Z"
+    ],
+    "\uff8c\uff9f\uff98\uff8a\uff9f\uff97&\uff8c\uff9f\uff98\uff83\uff68\uff70\uff98\uff7d\uff9e\uff91 \uff8c\uff9f\uff98\uff8a\uff9f\uff97\u3067\\n\u3064\u304b\u3048\u308b\u304a\u3057\u3083\u308c\uff71\uff72\uff83\uff911450!": [
+        "BPAJ"
+    ],
+    "\u304b\u308f\u3044\u3044\u4ed4\u72ac3D": [
+        "ACTJ"
+    ],
+    "\u3053\u3073\u3068\u3065\u304b\u3093\\n\u3053\u3073\u3068\u306e\u4e0d\u601d\u8b70 \u5b9f\u9a13\u30bb\u30c3\u30c8": [
+        "BK2J"
+    ],
+    "\u9ed2\u5b50\u306e\u30d0\u30b9\u30b1\\n\u672a\u6765\u3078\u306e\u30ad\u30ba\u30ca": [
+        "AK5J"
+    ],
+    "\u9ed2\u5b50\u306e\u30d0\u30b9\u30b1\\n\u52dd\u5229\u3078\u306e\u30ad\u30bb\u30ad": [
+        "BASJ"
+    ],
+    "\u3053\u3073\u3068\u3065\u304b\u3093\\n\u3053\u3073\u3068\u89b3\u5bdf\u30bb\u30c3\u30c8": [
+        "AKVJ"
+    ],
+    "\u30d9\u30a4\u30de\u30c3\u30af\u30b9\\n\u30d2\u30fc\u30ed\u30fc\u30ba\u30d0\u30c8\u30eb": [
+        "BH6J"
+    ],
+    "\u30e2\u30f3\u30cf\u30f3\u65e5\u8a18\\n\u307d\u304b\u307d\u304b\u30a2\u30a4\u30eb\u30fc\u6751DX": [
+        "BARJ"
+    ],
+    "\u5927\u9006\u8ee2\u88c1\u5224\uff12\\n\u2015\u6210\u6b69\u5802\u9f8d\u30ce\u4ecb\u306e\u89ba\u609f\u2015": [
+        "AJ2J"
+    ],
+    "\u30b7\u30a2\u30c8\u30ea\u30ba\u30e0\\n\u30d5\u30a1\u30a4\u30ca\u30eb\u30d5\u30a1\u30f3\u30bf\u30b8\u30fc": [
+        "ATHJ"
+    ],
+    "\u305f\u307e\u3054\u3063\u3061\u306e\\n\u30c9\u30ad\u30c9\u30ad\u2606\u30c9\u30ea\u30fc\u30e0\u304a\u307f\u305b\u3063\u3061": [
+        "AT8J"
+    ],
+    "\u305f\u307e\u3054\u3063\u3061\uff01\\n\u305b\u30fc\u3057\u3085\u3093\u306e\u30c9\u30ea\u30fc\u30e0\u30b9\u30af\u30fc\u30eb": [
+        "BD6J"
+    ],
+    "\u3061\u3073\u2606\u30c7\u30d3\uff01": [
+        "AD8J"
+    ],
+    "\u3077\u3088\u3077\u3088\uff01\uff01": [
+        "AP2J"
+    ],
+    "\u30a2\u30a4\u30c9\u30eb\u30bf\u30a4\u30e0 \u30d7\u30ea\u30d1\u30e9\\n\u5922\u30aa\u30fc\u30eb\u30b9\u30bf\u30fc\u30e9\u30a4\u30d6\uff01": [
+        "B2PJ"
+    ],
+    "\u30c0\u30f3\u30dc\u30fc\u30eb\u6226\u6a5f \u7206\u30d6\u30fc\u30b9\u30c8": [
+        "ADNJ"
+    ],
+    "\u63a2\u5075\u795e\u5bae\u5bfa\u4e09\u90ce \u5fa9\u8b90\u306e\u8f2a\u821e": [
+        "AJGJ"
+    ],
+    "\u304a\u3046\u3061\u307e\u3044\u306b\u3061 \u305f\u307e\u3054\u3063\u3061": [
+        "AQCJ"
+    ],
+    "\u30ab\u30bf\u30c1\u65b0\u767a\u898b\uff01 \u7acb\u4f53\u30d4\u30af\u30ed\u30b9\uff12": [
+        "BBPJ"
+    ],
+    "\u77ac\u8db3\u3000\u3081\u3056\u305b\uff01 \u5168\u56fd\u6700\u5f37\u30e9\u30f3\u30ca\u30fc": [
+        "BSNJ"
+    ],
+    "\u30cf\u30a4\u30b9\u30af\u30fc\u30eb\uff24\u00d7\uff24": [
+        "BDDJ"
+    ],
+    "\u30ba\u30fc\u30ad\u30fc\u30d1\u30fc\uff13D": [
+        "AZKJ"
+    ],
+    "\u30c0\u30f3\u30dc\u30fc\u30eb\u6226\u6a5fW \u8d85\u30ab\u30b9\u30bf\u30e0": [
+        "BDWJ"
+    ],
+    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30ebZ\\n\u8d85\u7a76\u6975\u6b66\u95d8\u4f1d": [
+        "BDVJ"
+    ],
+    "\u63a2\u5075\u795e\u5bae\u5bfa\u4e09\u90ce\\nGHOST OF THE DUSK": [
+        "BG9J"
+    ],
+    "\u4e16\u754c\u6a39\u306e\u8ff7\u5bae\u2163\\n\u4f1d\u627f\u306e\u5de8\u795e": [
+        "ASJJ"
+    ],
+    "\u30da\u30f3\u30ae\u30f3\u306e\u554f\u984c\\n\u30b6\u30fb\u30a6\u30a9\u30fc\u30ba": [
+        "AP5J"
+    ],
+    "\u30ec\u30a4\u30c8\u30f3\u6559\u6388\u3068\\n\u8d85\u6587\u660e\uff21\u306e\u907a\u7523": [
+        "AL6J"
+    ],
+    "\u96e3\u653b\u4e0d\u843d\u4e09\u56fd\u4f1d\\n\uff5e\u8700\u3068\u6642\u306e\u9285\u96c0\uff5e": [
+        "BSDJ"
+    ],
+    "\u6589\u6728\u6960\u96c4\u306e\u03a8\u96e3\\n\u53f2\u4e0a\u03a8\u5927\u306e\u03a8\u96e3\uff01\uff1f": [
+        "AKAJ"
+    ],
+    "\u30e9\u30f3\u30b0\u30ea\u30c3\u30b5\u30fc\\n\u30ea\u30a4\u30f3\u30ab\u30fc\u30cd\u30fc\u30b7\u30e7\u30f3 -\u8ee2\u751f-": [
+        "BRGJ"
+    ],
+    "\u3061\u3073\u2606\u30c7\u30d3\uff01\uff12\\n\uff5e\u9b54\u6cd5\u306e\u3086\u3081\u3048\u307b\u3093\uff5e": [
+        "ADSJ"
+    ],
+    "\u30af\u30c3\u30ad\u30f3\u30b0\u30de\u30de\\n\u308f\u305f\u3057\u306e\u30b9\u30a4\u30fc\u30c4\u30b7\u30e7\u30c3\u30d7": [
+        "BS8J"
+    ],
+    "\u602a\u76d7\u30b8\u30e7\u30fc\u30ab\u30fc\\n\u6642\u3092\u8d85\u3048\u308b\u602a\u76d7\u3068\u5931\u308f\u308c\u305f\u5b9d\u77f3": [
+        "AKJJ"
+    ],
+    "\u3061\u3087\uff5e\u308a\u3063\u3061\uff01\\n\u305f\u307e\u3054\u3063\u3061\u306e\u30d7\u30c1\u30d7\u30c1\u304a\u307f\u305b\u3063\u3061": [
+        "AT5J"
+    ],
+    "\u30de\u30ea\u30aa\u30ab\u30fc\u30c8\uff17": [
+        "AMKJ"
+    ],
+    "\u771f\u30fb\u5973\u795e\u8ee2\u751f\u2163": [
+        "AMXJ",
+        "AMXZ"
+    ],
+    "\u30d2\u30fc\u30ed\u30fc\u30d0\u30f3\u30af": [
+        "BHBJ"
+    ],
+    "\u30c8\u30e9\u30a4\u30d6\u30af\u30eb\u30af\u30eb THE G@ME": [
+        "BQRJ"
+    ],
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u7fbd\u7530 ALL STARS": [
+        "BKAJ"
+    ],
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u6210\u7530 ALL STARS": [
+        "BNAJ"
+    ],
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u95a2\u7a7a ALL STARS": [
+        "BPKJ"
+    ],
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u90a3\u8987 PREMIUM": [
+        "AX5J"
+    ],
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u95a2\u7a7a SKY STORY": [
+        "AKXJ"
+    ],
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u7fbd\u7530 with \uff2a\uff21\uff2c": [
+        "AH7J"
+    ],
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u6210\u7530 with \uff21\uff2e\uff21": [
+        "AN6J"
+    ],
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u65b0\u5343\u6b73 with \uff2a\uff21\uff2c": [
+        "BBKJ"
+    ],
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u30db\u30ce\u30eb\u30eb": [
+        "AHWJ"
+    ],
+    "\u30aa\u30ec\u69d8\u30ad\u30f3\u30b0\u30c0\u30e0 \uff72\uff79\uff92\uff9d\u5f7c\u6c0f\u3092\\n\uff79\uff9e\uff6f\uff84\u3057\u3088\uff01\u3082\u3048\uff77\uff6d\uff9d\u2665\uff7d\uff78\uff70\uff99\uff83\uff9e\uff72\uff7d\uff9e": [
+        "AK7J"
+    ],
+    "\u30c7\u30d3\u30eb\u30b5\u30d0\u30a4\u30d0\u30fc \u30aa\u30fc\u30d0\u30fc\u30af\u30ed\u30c3\u30af": [
+        "ADVJ"
+    ],
+    "\u30c7\u30d3\u30eb\u30b5\u30d0\u30a4\u30d0\u30fc2\\n\u30d6\u30ec\u30a4\u30af\u30ec\u30b3\u30fc\u30c9": [
+        "ADXJ"
+    ],
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO2\\n\u30af\u30ed\u30ce\u30fb\u30b9\u30c8\u30fc\u30f3 \"\u30cd\u30c3\u30d7\u30a6\"": [
+        "ANPJ"
+    ],
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO2\\n\u30af\u30ed\u30ce\u30fb\u30b9\u30c8\u30fc\u30f3 \"\u30e9\u30a4\u30e1\u30a4\"": [
+        "ARAJ"
+    ],
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\\n\u30c0\u30fc\u30af": [
+        "AEDJ"
+    ],
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\\n\u30b7\u30e3\u30a4\u30f3": [
+        "AE4J"
+    ],
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\\n\u30ae\u30e3\u30e9\u30af\u30b7\u30fc \u30d3\u30c3\u30b0\u30d0\u30f3": [
+        "BGVJ"
+    ],
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\\n\u30ae\u30e3\u30e9\u30af\u30b7\u30fc \u30b9\u30fc\u30d1\u30fc\u30ce\u30f4\u30a1": [
+        "BGSJ"
+    ],
+    "\u30c7\u30b8\u30e2\u30f3\u30ef\u30fc\u30eb\u30c9\\nRe:Digitize Decode": [
+        "ADJJ"
+    ],
+    "\u30de\u30ea\u30aa\uff06\u30bd\u30cb\u30c3\u30af\\n\uff21\uff34 \u30ed\u30f3\u30c9\u30f3\u30aa\u30ea\u30f3\u30d4\u30c3\u30af": [
+        "ACMJ"
+    ],
+    "\u30a2\u30af\u30ea\u30eb\u30d1\u30ec\u30c3\u30c8\\n\uff5e\u5f69\u308a\u30ab\u30d5\u30a7\u30fbCheers\uff5e": [
+        "AYDJ"
+    ],
+    "\u30e9\u30f3\u30ca\u30d0\u30a6\u30c8\uff13\uff24\\n\u30c9\u30e9\u30a4\u30d6\uff1a\u30a4\u30f3\u30dd\u30c3\u30b7\u30d6\u30eb": [
+        "ARNJ"
+    ],
+    "\u68a8\u6c41\u30a2\u30af\u30b7\u30e7\u30f3\uff01\\n\u3075\u306a\u3063\u3057\u30fc\u306e\u6109\u5feb\u306a\u304a\u306f\u306a\u3063\u3057\u30fc": [
+        "BFCJ"
+    ],
+    "\u65b0\u30c6\u30cb\u30b9\u306e\u738b\u5b50\u69d8\\n\uff5e\uff27\uff4f\u3000\uff54\uff4f\u3000\uff54\uff48\uff45\u3000\uff54\uff4f\uff50\uff5e": [
+        "BTPJ"
+    ],
+    "\uff4e\uff49\uff43\uff4f\uff4c\uff41\u76e3\u4fee\\n\u30e2\u30c7\u30eb\u2606\u304a\u3057\u3083\u308c\u30aa\u30fc\u30c7\u30a3\u30b7\u30e7\u30f3\uff12": [
+        "ANLJ"
+    ],
+    "\u30d7\u30ea\u30c6\u30a3\u30fc\u30ea\u30ba\u30e0\\n\u30de\u30a4\u2606\u30c7\u30b3\u30ec\u30a4\u30f3\u30dc\u30fc\u30a6\u30a8\u30c7\u30a3\u30f3\u30b0": [
+        "APTJ"
+    ],
+    "\u30af\u30c3\u30ad\u30f3\u30b0\u30de\u30de\uff14": [
+        "ACQJ"
+    ],
+    "\u30b8\u30e5\u30a8\u30eb\u30de\u30b9\u30bf\u30fc": [
+        "AJ5J"
+    ],
+    "\u30ed\u30b9\u30c8\u30d2\u30fc\u30ed\u30fc\u30ba": [
+        "ALHJ"
+    ],
+    "\u30e9\u30d3\u30ea\u30f3\u30b9\u306e\u5f7c\u65b9": [
+        "ALVJ"
+    ],
+    "\u96f7\u5b50\u2010\u7d3a\u78a7\u306e\u7ae0\u2010": [
+        "ARPJ"
+    ],
+    "\u4e0a\u6d77\uff13\uff24\u30ad\u30e5\u30fc\u30d6": [
+        "ASHJ"
+    ],
+    "\u6f22\u691c\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
+        "AXFJ"
+    ],
+    "\u661f\u971c\u306e\u30a2\u30de\u30be\u30cd\u30b9": [
+        "AZSJ"
+    ],
+    "\u30af\u30c3\u30ad\u30f3\u30b0\u30de\u30de\uff15": [
+        "BC5J"
+    ],
+    "\u30d2\u30fc\u30ed\u30fc\u30d0\u30f3\u30af\uff12": [
+        "BNKJ"
+    ],
+    "\u30b3\u30fc\u30d7\u30b9\u30d1\u30fc\u30c6\u30a3\u30fc \uff22\uff32": [
+        "BCPJ"
+    ],
+    "\u4e21\u76ee\u3067\u53f3\u8133\u3092\u935b\u3048\u308b \uff13\uff24\u901f\u8aad\u8853": [
+        "ASKJ"
+    ],
+    "\u30c7\u30a3\u30b9\u30af\u2022\u30a6\u30a9\u30fc\u30ba:\u30a2\u30d9\u30f3\u30b8\u30e3\u30fc\u30ba\\n\u30a2\u30eb\u30c6\u30a3\u30e1\u30c3\u30c8\u30d2\u30fc\u30ed\u30fc\u30ba": [
+        "AVNJ"
+    ],
+    "\u30a6\u30a4\u30eb\u30b9\u30b7\u30e5\u30fc\u30bf\u30fcXX": [
+        "AV4J"
+    ],
+    "\u30ed\u30b9\u30c8\u30d2\u30fc\u30ed\u30fc\u30ba\uff12\\nPREMIUM EDITION": [
+        "BL3J"
+    ],
+    "\u30af\u30ec\u30e8\u30f3\u3057\u3093\u3061\u3083\u3093\\n\u5b87\u5b99DE\u30a2\u30c1\u30e7\u30fc!?": [
+        "ACHJ"
+    ],
+    "\u30c7\u30b8\u30e2\u30f3\u30e6\u30cb\u30d0\u30fc\u30b9\\n\u30a2\u30d7\u30ea\u30e2\u30f3\u30b9\u30bf\u30fc\u30ba": [
+        "AUDJ"
+    ],
+    "\u6226\u95d8\u4e2d\u3000\u4f1d\u8aac\u306e\u5fcd\u3068\\n\u30b5\u30d0\u30a4\u30d0\u30eb\u30d0\u30c8\u30eb\uff01": [
+        "BCBJ"
+    ],
+    "\u30a2\u30a4\u30ab\u30c4\u30b9\u30bf\u30fc\u30ba\uff01\\n\uff2d\uff59\u30b9\u30da\u30b7\u30e3\u30eb\u30a2\u30d4\u30fc\u30eb": [
+        "AKFJ"
+    ],
+    "\u6843\u592a\u90ce\u96fb\u9244\uff12\uff10\uff11\uff17\\n\uff5e\u305f\u3061\u3042\u304c\u308c\u65e5\u672c\uff01\uff01\uff5e": [
+        "AKQJ"
+    ],
+    "\u5fcd\u8005\u3058\u3083\u3058\u3083\u4e38\u304f\u3093\\n\u3055\u304f\u3089\u59eb\u3068\u706b\u7adc\u306e\u3072\u307f\u3064": [
+        "ANNJ"
+    ],
+    "\u30aa\u30fc\u30eb\u4eee\u9762\u30e9\u30a4\u30c0\u30fc\\n\u30e9\u30a4\u30c0\u30fc\u30ec\u30dc\u30ea\u30e5\u30fc\u30b7\u30e7\u30f3": [
+        "ARUJ"
+    ],
+    "\u9003\u8d70\u4e2d\u3000\u53f2\u4e0a\u6700\u5f37\u306e\\n\u30cf\u30f3\u30bf\u30fc\u305f\u3061\u304b\u3089\u306b\u3052\u304d\u308c\uff01": [
+        "ATCJ"
+    ],
+    "\u30af\u30ec\u30e8\u30f3\u3057\u3093\u3061\u3083\u3093\\n\u6fc0\u30a2\u30c4\uff01\u304a\u3067\u3093\u308f\uff5e\u308b\u3069\u5927\u30b3\u30f3\u4e71!!": [
+        "BWKJ"
+    ],
+    "\u30af\u30ec\u30e8\u30f3\u3057\u3093\u3061\u3083\u3093\\n\u5d50\u3092\u547c\u3076\u3000\u30ab\u30b9\u30ab\u30d9\u6620\u753b\u30b9\u30bf\u30fc\u30ba\uff01": [
+        "BGBJ"
+    ],
+    "\u6226\u56fd\u7121\u53cc\u30af\u30ed\u30cb\u30af\u30eb": [
+        "A66J"
+    ],
+    "\u30a8\u30af\u30b9\u30c8\u30eb\u30fc\u30d1\u30fc\u30ba": [
+        "ALTJ"
+    ],
+    "\u6f22\u691c\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0\uff12": [
+        "B2KJ"
+    ],
+    "\u30ed\u30b9\u30c8\u30d2\u30fc\u30ed\u30fc\u30ba\uff12": [
+        "BL2J"
+    ],
+    "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0 if\\n\u767d\u591c\u738b\u56fd": [
+        "BFXJ"
+    ],
+    "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0 if\\n\u6697\u591c\u738b\u56fd": [
+        "BFYJ"
+    ],
+    "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0 if": [
+        "BFZJ"
+    ],
+    "\u30a2\u30f3\u30c1\u30a7\u30a4\u30f3\u30d6\u30ec\u30a4\u30ba \u30ec\u30af\u30b9": [
+        "AUCJ"
+    ],
+    "\u30a2\u30f3\u30c1\u30a7\u30a4\u30f3\u30d6\u30ec\u30a4\u30ba \u30a8\u30af\u30b7\u30f4": [
+        "AUXJ"
+    ],
+    "\u5b9f\u6cc1\u30d1\u30ef\u30d5\u30eb\u30d7\u30ed\u91ce\u7403 \u30d2\u30fc\u30ed\u30fc\u30ba\\n\u3010\u4f53\u9a13\u7248\u3011": [
+        "AWYJ"
+    ],
+    "\u5b9f\u6cc1\u30d1\u30ef\u30d5\u30eb\u30d7\u30ed\u91ce\u7403 \u30d2\u30fc\u30ed\u30fc\u30ba": [
+        "BPYJ"
+    ],
+    "\u30ac\u30f3\u30c0\u30e0\u30c8\u30e9\u30a4\u30a8\u30a4\u30b8SP": [
+        "BTAJ"
+    ],
+    "\u30ca\u30ca\u30df\u3068\u4e00\u7dd2\u306b\u5b66\u307c\uff01\\nEnglish\u4e0a\u9054\u306e\u30b3\u30c4": [
+        "AYVJ"
+    ],
+    "\u308f\u304c\u307e\u307e\u30d5\u30a1\u30c3\u30b7\u30e7\u30f3\\nGIRLS MODE\u3000\u3088\u304f\u3070\u308a\u5ba3\u8a00\uff01": [
+        "ACLJ"
+    ],
+    "\u3067\u3093\u3062\u3083\u3089\u3059\u3058\u30fc\u3055\u3093\\n\u30681000\u4eba\u306e\u304a\u53cb\u3060\u3061\u90aa": [
+        "ADZJ"
+    ],
+    "\u30b9\u30fc\u30d1\u30fc\u30d6\u30e9\u30c3\u30af\u30d0\u30b9\\n\uff13\uff24\u30d5\u30a1\u30a4\u30c8": [
+        "ASBJ"
+    ],
+    "\u30d3\u30c3\u30af\u30ea\u30de\u30f3\u6f22\u719f\u8987\u738b\\n\u4e09\u4f4d\u52d5\u4e71\u6226\u5275\u7d00": [
+        "AB9J"
+    ],
+    "\u3046\u3057\u307f\u3064\u30e2\u30f3\u30b9\u30c8\u30eb\u30aa\\n\u30ea\u30f3\u30bc\u3068\u9b54\u6cd5\u306e\u30ea\u30ba\u30e0": [
+        "AG3J"
+    ],
+    "\u3082\u306e\u3059\u3054\u304f\u8133\u3092\u935b\u3048\u308b\\n\uff15\u5206\u9593\u306e\u9b3c\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
+        "ASRJ"
+    ],
+    "\u30df\u30e9\u30af\u30eb\u3061\u3085\u30fc\u3093\u305a\uff01\\n\u30b2\u30fc\u30e0\u3067\u30c1\u30e5\u30fc\u30f3\u30a2\u30c3\u30d7\uff01 \u3060\u30d7\u30f3\uff01": [
+        "BG7J"
+    ],
+    "\u30e9\u30b8\u30a2\u30f3\u30c8\u30d2\u30b9\u30c8\u30ea\u30a2\\n\u30d1\u30fc\u30d5\u30a7\u30af\u30c8\u30af\u30ed\u30ce\u30ed\u30b8\u30fc": [
+        "BRBJ"
+    ],
+    "\u5973\u306e\u5b50\u3068\u5bc6\u5ba4\u306b\u3044\u305f\u3089\\n\u25cb\u25cb\u3057\u3061\u3083\u3046\u304b\u3082\u3057\u308c\u306a\u3044\u3002": [
+        "AWMJ"
+    ],
+    "\u30b9\u30de\u30a4\u30eb\u30d7\u30ea\u30ad\u30e5\u30a2\uff01\\n\u30ec\u30c3\u30c4\u30b4\u30fc\uff01\u30e1\u30eb\u30d8\u30f3\u30ef\u30fc\u30eb\u30c9": [
+        "APQJ"
+    ],
+    "\u521d\u5fc3\u8005\u304b\u3089\u65e5\u672c\u4e00\u307e\u3067\\n\u305d\u308d\u3070\u3093\u30fb\u3042\u3093\u3056\u3093\u30fb\uff8c\uff97\uff6f\uff7c\uff6d\u6697\u7b97": [
+        "AFUJ"
+    ],
+    "\u59eb\u30ae\u30e3\u30eb\u2665\u30d1\u30e9\u30c0\u30a4\u30b9\\n\u30e1\u30c1\u30ab\u30ef\uff01\u30a2\u30b2\u76db\u308a\u2191\uff7e\uff9d\uff7e\uff70\uff7c\uff6e\uff9d\uff01": [
+        "AHGJ"
+    ],
+    "\u30eb\u30a4\u30fc\u30b8\u30de\u30f3\u30b7\u30e7\u30f3\uff12": [
+        "AGGJ"
+    ],
+    "\u82b1\u3068\u3044\u304d\u3082\u306e\u7acb\u4f53\u56f3\u9451": [
+        "ASUJ"
+    ],
+    "\u30e2\u30f3\u30b9\u30bf\u30fc\u30b9\u30c8\u30e9\u30a4\u30af": [
+        "BFLJ"
+    ],
+    "\u3050\u308b\u3050\u308b\u305f\u307e\u3054\u3063\u3061\uff01": [
+        "BGGJ"
+    ],
+    "\u3061\u3083\u304a\u30a4\u30e9\u30b9\u30c8\u30af\u30e9\u30d6": [
+        "BMDJ"
+    ],
+    "\u30d6\u30ec\u30a4\u30d6\u30ea\u30fc\u30bb\u30ab\u30f3\u30c9": [
+        "BSEJ"
+    ],
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073 \u304d\u304b\u3093\u3057\u3083\\n\u30c8\u30fc\u30de\u30b9\u7de8 \u5927\u4e95\u5ddd\u9435\u9053\u3092\u8d70\u308d\u3046\uff01": [
+        "BTGJ"
+    ],
+    "\u3068\u3073\u3060\u3059\uff01\u30d1\u30ba\u30eb\u30dc\u30d6\u30eb3D": [
+        "ABBJ"
+    ],
+    "\u30d0\u30f3\u30c0\u30a4\u30ca\u30e0\u30b3\u30b2\u30fc\u30e0\u30b9PRESENTS\\nJ\u30ec\u30b8\u30a7\u30f3\u30c9\u5217\u4f1d": [
+        "BNGJ"
+    ],
+    "\u904a\u3093\u3067\u5c06\u68cb\u304c\u5f37\u304f\u306a\u308b\uff01\\n\u9280\u661f\u5c06\u68cbDX": [
+        "BSGJ"
+    ],
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u8fd1\u6c5f\u9244\u9053\u7de8": [
+        "ATJJ"
+    ],
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u53e1\u5c71\u96fb\u8eca\u7de8": [
+        "BEDJ"
+    ],
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u4f1a\u6d25\u9244\u9053\u7de8": [
+        "BTXJ"
+    ],
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u9577\u826f\u5ddd\u9244\u9053\u7de8": [
+        "ARJJ"
+    ],
+    "\u304a\u3055\u308f\u308a\u63a2\u5075\u3000\u5c0f\u6ca2\u91cc\u5948\\n\u306a\u3081\u3053\u30ea\u30ba\u30e0": [
+        "BSLJ"
+    ],
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u3086\u3044\u30ec\u30fc\u30eb\u7de8": [
+        "BTYJ"
+    ],
+    "\u30dd\u30b1\u30c3\u30c8\u30b5\u30c3\u30ab\u30fc\u30ea\u30fc\u30b0\\n\u30ab\u30eb\u30c1\u30e7\u30d3\u30c3\u30c8": [
+        "AHBJ"
+    ],
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u9e7f\u5cf6\u81e8\u6d77\u9244\u9053\u7de8": [
+        "ARKJ"
+    ],
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u4e0a\u6bdb\u96fb\u6c17\u9244\u9053\u7de8": [
+        "BTJJ"
+    ],
+    "\u84bc\u304d\u96f7\u9706\u3000\u30ac\u30f3\u30f4\u30a9\u30eb\u30c8\\n\u30b9\u30c8\u30e9\u30a4\u30ab\u30fc\u30d1\u30c3\u30af": [
+        "BG8J"
+    ],
+    "\u30a2\u30f3\u30d1\u30f3\u30de\u30f3\u3068\u30bf\u30c3\u30c1\u3067\\n\u308f\u304f\u308f\u304f\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
+        "BWTJ"
+    ],
+    "\u50d5\u306e\u30d2\u30fc\u30ed\u30fc\u30a2\u30ab\u30c7\u30df\u30a2\\n\u30d0\u30c8\u30eb\u30fb\u30d5\u30a9\u30fc\u30fb\u30aa\u30fc\u30eb": [
+        "BHAJ"
+    ],
+    "\u30d6\u30ec\u30a4\u30d6\u30ea\u30fc\u30c7\u30d5\u30a9\u30eb\u30c8\\n\u30d5\u30a9\u30fc\u30b6\u30fb\u30b7\u30fc\u30af\u30a6\u30a7\u30eb": [
+        "BTRJ"
+    ],
+    "\u8b0e\u89e3\u304d\u30d0\u30c8\u30eb\uff34\uff2f\uff32\uff25\uff01\\n\u4f1d\u8aac\u306e\u9b54\u5bae\u3092\u5fa9\u6d3b\u3055\u305b\u3088\uff01": [
+        "BREJ"
+    ],
+    "\u30d6\u30ec\u30a4\u30d6\u30ea\u30fc\u30c7\u30d5\u30a9\u30eb\u30c8": [
+        "AFFJ"
+    ],
+    "\u5275\u4f5c\u30a2\u30ea\u30b9\u3068\u738b\u5b50\u3055\u307e\uff01": [
+        "ARZJ"
+    ],
+    "\u30c0\u30f3\u30dc\u30fc\u30eb\u6226\u6a5f\uff37\uff21\uff32\uff33": [
+        "BDNJ"
+    ],
+    "\u30dd\u30dd\u30ed\u30af\u30ed\u30a4\u30b9\u7267\u5834\u7269\u8a9e": [
+        "BPPJ"
+    ],
+    "\u304a\u305d\u677e\u3055\u3093\u3000\u677e\u307e\u3064\u308a\uff01": [
+        "BW3J"
+    ],
+    "\u5c0f\u6797\u304c\u53ef\u611b\u3059\u304e\u3066\u30c4\u30e9\u30a4\u3063!!": [
+        "BKQJ"
+    ],
+    "\u30c9\u30e9\u30a4\u30d0\u30fc\uff1a\u30ec\u30cd\u30b2\u30a4\u30c9\uff13D": [
+        "ADRJ"
+    ],
+    "\u7a7a\u9593\u3055\u304c\u3057\u3082\u306e\u7cfb\u8133\u529b\u958b\u767a\\n\uff13\uff24\u8133\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
+        "AKTJ"
+    ],
+    "\u5927\u6226\u7565\u3000\u5927\u6771\u4e9c\u8208\u4ea1\u53f2\uff24\uff38\\n\uff5e\u7b2c\u4e8c\u6b21\u4e16\u754c\u5927\u6226\uff5e": [
+        "BFEJ"
+    ],
+    "\u30cf\u30ed\u30fc\u30ad\u30c6\u30a3\u3068\u3044\u3063\u3057\u3087\uff01\\n\u30d6\u30ed\u30c3\u30af\u30af\u30e9\u30c3\u30b7\u30e5\uff3a": [
+        "AHZJ"
+    ],
+    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u3000\u5927\u6d77\u7269\u8a9e\uff12\\n\uff5e\u30d1\u30c1\u30d7\u30ed\u98a8\u96f2\u9332\u30fb\u82b1\uff5e": [
+        "AU3J"
+    ],
+    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u3000\u5927\u6d77\u7269\u8a9e\uff12\\n\uff37\uff49\uff54\uff48\u3000\u30a2\u30b0\u30cd\u30b9\u30fb\u30e9\u30e0": [
+        "AU2J"
+    ],
+    "\u30c7\u30a3\u30ba\u30cb\u30fc\u30a4\u30f3\u30d5\u30a3\u30cb\u30c6\u30a3\\n\u30c8\u30a4\u30fb\u30dc\u30c3\u30af\u30b9\u30fb\u30c1\u30e3\u30ec\u30f3\u30b8": [
+        "ADYJ"
+    ],
+    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30eb\u30d2\u30fc\u30ed\u30fc\u30ba\\n\u30a2\u30eb\u30c6\u30a3\u30e1\u30c3\u30c8\u30df\u30c3\u30b7\u30e7\u30f3\uff38": [
+        "BD9J"
+    ],
+    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30eb\u30d2\u30fc\u30ed\u30fc\u30ba\\n\u30a2\u30eb\u30c6\u30a3\u30e1\u30c3\u30c8\u30df\u30c3\u30b7\u30e7\u30f3\uff12": [
+        "BDBJ"
+    ],
+    "\u5263\u3068\u9b54\u6cd5\u3068\u5b66\u5712\u30e2\u30ce\u3002\uff13\uff24": [
+        "AKNJ"
+    ],
+    "\u307f\u3093\u306a\u3067\u30aa\u30fc\u30c8\u30ec\u30fc\u30b9\uff13\uff24": [
+        "ARCJ"
+    ],
+    "\u30b9\u30fc\u30d1\u30fc\u30ed\u30dc\u30c3\u30c8\u5927\u6226\uff35\uff38": [
+        "AS6J"
+    ],
+    "\u30c9\u30ea\u30fc\u30e0\u30ac\u30fc\u30eb\u3000\u30d7\u30eb\u30df\u30a8": [
+        "BMVJ"
+    ],
+    "\u30b9\u30fc\u30d1\u30fc\u30ed\u30dc\u30c3\u30c8\u5927\u6226\uff22\uff38": [
+        "BSRJ"
+    ],
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3\uff11\u30fb\uff12\u30fb\uff13!!\\n\u5186\u5802\u5b88\u4f1d\u8aac": [
+        "AETJ"
+    ],
+    "\uff27\uff4f\uff01\u30d7\u30ea\u30f3\u30bb\u30b9\u30d7\u30ea\u30ad\u30e5\u30a2\\n\u30b7\u30e5\u30ac\u30fc\u738b\u56fd\u30686\u4eba\u306e\u30d7\u30ea\u30f3\u30bb\u30b9\uff01": [
+        "BG5J"
+    ],
+    "\u30c8\u30fc\u30de\u30b9\u3068\u3042\u305d\u3093\u3067\u304a\u307c\u3048\u308b\\n\u3053\u3068\u3070\u3068\u304b\u305a\u3068ABC": [
+        "BTFJ"
+    ],
+    "\u7363\u96fb\u6226\u968a\u30ad\u30e7\u30a6\u30ea\u30e5\u30a6\u30b8\u30e3\u30fc\\n\u30b2\u30fc\u30e0\u3067\u30ac\u30d6\u30ea\u30f3\u30c1\u30e7\uff01\uff01": [
+        "AAKJ"
+    ],
+    "\u30ac\u30fc\u30eb\u30ba\u30d5\u30a1\u30c3\u30b7\u30e7\u30f3\uff13\uff24\u2606\\n\u3081\u3056\u305b\uff01\u30c8\u30c3\u30d7\u30b9\u30bf\u30a4\u30ea\u30b9\u30c8": [
+        "AGUJ"
+    ],
+    "\u304b\u308f\u3044\u3044\u30da\u30c3\u30c8\u3068\u304f\u3089\u305d\u3046\uff01\\n\u308f\u3093\u30cb\u30e3\u30f3\uff06\u30df\u30cb\u30df\u30cb\u30a2\u30cb\u30de\u30eb": [
+        "BHSJ"
+    ],
+    "\u304b\u308f\u3044\u3044\u30da\u30c3\u30c8\u3068\u304f\u3089\u305d\u3046\uff01\\n\u308f\u3093\u30cb\u30e3\u30f3\uff06\u30a2\u30a4\u30c9\u30eb\u30a2\u30cb\u30de\u30eb": [
+        "BWAJ"
+    ],
+    "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0\u3000\u899a\u9192": [
+        "AFEJ"
+    ],
+    "\u5927\u5408\u594f\uff01\u30d0\u30f3\u30c9\u30d6\u30e9\u30b6\u30fc\u30ba\uff30": [
+        "ANEJ"
+    ],
+    "\u304a\u3055\u308f\u308a\u63a2\u5075\u3000\u306a\u3081\u3053\u5927\u7e41\u6b96": [
+        "APMJ"
+    ],
+    "\u771f\u30fb\u5973\u795e\u8ee2\u751f\u2163\u3000\uff26\uff29\uff2e\uff21\uff2c": [
+        "BG4J"
+    ],
+    "\u30cf\u30d4\u30cd\u30b9\u30c1\u30e3\u30fc\u30b8\u30d7\u30ea\u30ad\u30e5\u30a2\uff01\\n\u304b\u308f\u30eb\u30f3\u2606\u30b3\u30ec\u30af\u30b7\u30e7\u30f3": [
+        "BHCJ"
+    ],
+    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u30d7\u30ec\u30df\u30a2\u30e0\u6d77\u7269\u8a9e\\n\uff5e\u5922\u898b\u308b\u4e59\u5973\u3068\u30d1\u30c1\u30f3\u30b3\u738b\u6c7a\u5b9a\u6226\uff5e": [
+        "AUMJ"
+    ],
+    "\u6226\u56fd\u7121\u53cc\u30af\u30ed\u30cb\u30af\u30eb\u3000\u30bb\u30ab\u30f3\u30c9": [
+        "AZCJ"
+    ],
+    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30eb\u30d5\u30e5\u30fc\u30b8\u30e7\u30f3\u30ba": [
+        "BDLJ"
+    ],
+    "\u30c8\u30e2\u30c0\u30c1\u30b3\u30ec\u30af\u30b7\u30e7\u30f3\u3000\u65b0\u751f\u6d3b": [
+        "EC6J"
+    ],
+    "\u30e2\u30c7\u30eb\u2606\u304a\u3057\u3083\u308c\u30aa\u30fc\u30c7\u30a3\u30b7\u30e7\u30f3\\n\u30d7\u30e9\u30c1\u30ca": [
+        "AN9J"
+    ],
+    "\u30aa\u30b7\u30e3\u30ec\u3067\u304b\u308f\u3044\u3044\u5b50\u72ac\u3068\u904a\u307c\uff01\\n\uff0d\u6d77\u7de8\uff0d": [
+        "APIJ"
+    ],
+    "\u30aa\u30b7\u30e3\u30ec\u3067\u304b\u308f\u3044\u3044\u5b50\u72ac\u3068\u904a\u307c\uff01\\n\uff0d\u8857\u7de8\uff0d": [
+        "APOJ"
+    ],
+    "\u30e2\u30c7\u30eb\u2606\u304a\u3057\u3083\u308c\u30aa\u30fc\u30c7\u30a3\u30b7\u30e7\u30f3\\n\u30c9\u30ea\u30fc\u30e0\u30ac\u30fc\u30eb": [
+        "AYCJ"
+    ],
+    "\u30cf\u30ed\u30fc\u30ad\u30c6\u30a3\u3068\u307e\u307b\u3046\u306e\u30a8\u30d7\u30ed\u30f3\\n\u30ea\u30ba\u30e0\u30af\u30c3\u30ad\u30f3\u30b0\u266a": [
+        "BHKJ"
+    ],
+    "\uff2d\uff2f\uff25\uff2d\uff2f\uff25\uff24\uff21\uff29\uff33\uff25\uff2e\uff33\uff2f\uff35\\n\uff27\uff25\uff2e\uff24\uff21\uff29\uff22\uff21\uff2e\uff13\uff24": [
+        "AMAJ"
+    ],
+    "\u306d\u3089\u3063\u3066\uff01\u3068\u3070\u3057\u3066\uff01\u30ea\u30e9\u30c3\u30af\u30de\\n\u3050\u3089\u3050\u3089\u30b9\u30a4\u30fc\u30c4\u30bf\u30ef\u30fc": [
+        "ARLJ"
+    ],
+    "\u30c9\u30e9\u3048\u3082\u3093\u3000\u306e\u3073\u592a\u306e\u5b87\u5b99\u82f1\u96c4\u8a18\\n\uff08\u30b9\u30da\u30fc\u30b9\u30d2\u30fc\u30ed\u30fc\u30ba\uff09": [
+        "BS5J"
+    ],
+    "\u30c7\u30a3\u30ba\u30cb\u30fc\u3000\u30de\u30b8\u30c3\u30af\u30ad\u30e3\u30c3\u30b9\u30eb\\n\u30de\u30a4\u30fb\u30cf\u30c3\u30d4\u30fc\u30fb\u30e9\u30a4\u30d5\uff12": [
+        "BD2J"
+    ],
+    "\u305f\u307e\u3054\u3063\u3061\u306e\u30d7\u30c1\u30d7\u30c1\u304a\u307f\u305b\u3063\u3061\\n\uff5e\u306b\u3093\u304d\u306e\u304a\u307f\u305b\u3042\u3064\u3081\u307e\u3057\u305f\uff5e": [
+        "BT4J"
+    ],
+    "\u3073\u3063\u304f\u308a\uff01\u3068\u3073\u3060\u3059\uff01\u9b54\u6cd5\u306e\u30da\u30f3": [
+        "AMPJ"
+    ],
+    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u3000\u30c7\u30e9\u30c3\u30af\u30b9\u6d77\u7269\u8a9e": [
+        "AU9J"
+    ],
+    "\u30b2\u30fc\u30e0\u30bb\u30f3\u30bf\u30fc\uff23\uff38\uff13\u4e01\u76ee\u306e\u6709\u91ce": [
+        "BCXJ"
+    ],
+    "\u30c6\u30f3\u30ab\u30a4\u30ca\u30a4\u30c8\u3000\u30d6\u30ec\u30a4\u30d6\u30d0\u30c8\u30eb": [
+        "BTKJ"
+    ],
+    "\u30d7\u30ea\u30c6\u30a3\u30fc\u30ea\u30ba\u30e0\u30ec\u30a4\u30f3\u30dc\u30fc\u30e9\u30a4\u30d6\\n\u304d\u3089\u304d\u3089\u30de\u30a4\u2606\u30c7\u30b6\u30a4\u30f3": [
+        "BP2J"
+    ],
+    "\u30c1\u30e7\u30b3\u72ac\u306e\u3061\u3087\u3053\u3063\u3068\u4e0d\u601d\u8b70\u306a\u7269\u8a9e\\n\u30b7\u30e7\u30b3\u30e9\u59eb\u3068\u9b54\u6cd5\u306e\u30ec\u30b7\u30d4": [
+        "BCHJ"
+    ],
+    "\u305d\u308d\u3070\u3093\u30fb\u3042\u3093\u3056\u3093\u30fb\uff8c\uff97\uff6f\uff7c\uff6d\u6697\u7b97\\n\u5b8c\u5168\u7248": [
+        "BSAJ"
+    ],
+    "\u30b9\u30e9\u30a4\u30e0\u3082\u308a\u3082\u308a\u30c9\u30e9\u30b4\u30f3\u30af\u30a8\u30b9\u30c8\uff13\\n\u5927\u6d77\u8cca\u3068\u3057\u3063\u307d\u56e3": [
+        "AMRJ"
+    ]
+}

--- a/data/ids/3ds.json
+++ b/data/ids/3ds.json
@@ -1,4086 +1,1148 @@
 {
-    "100\uff05 PASUKARU SENSEI\nPerfect Paint Bombers": [
-        "BP4J"
-    ],
-    "12 SAI TOROKERU Puzzle\nFUTARINO Harmony": [
-        "A2PJ"
-    ],
-    "12 SAI\nHONTOU NO KIMOCHI": [
-        "BTVJ"
-    ],
-    "12 SAI\nKOISURU Diary": [
-        "BA7J"
-    ],
-    "2in1: Horses 3D, Vol. 2": [
-        "BMRP"
-    ],
-    "2in1: Horses 3D, Vol. 3": [
-        "BM2P"
-    ],
-    "2in1: Horses 3D": [
-        "BMFP"
-    ],
-    "2in1:LifeHorses3D\n+BabyPetHotel3D": [
-        "BMXP"
-    ],
-    "2in1:VetCountry3D\n+BabyPetHotel3D": [
-        "BELP"
-    ],
-    "35 Classic Games": [
-        "AF5P"
-    ],
-    "3D Game Collection": [
-        "AD3D",
-        "AD3P"
-    ],
-    "3D MahJongg": [
-        "AG2P"
-    ],
-    "3in1 Horses": [
-        "BRZP"
-    ],
-    "4 Elements": [
-        "AELP"
-    ],
-    "50 Classic Games 3D": [
-        "AF6Z"
-    ],
-    "50 Classic Games": [
-        "AC5E",
-        "AF6P"
-    ],
-    "7TH DRAGON III CODE: VFD": [
-        "BD7E",
-        "BD7P"
-    ],
-    "7TH DRAGON \u2162 code:VFD": [
-        "BD7J"
-    ],
-    "A Penguin's Troubles +": [
-        "AYSJ"
-    ],
-    "A-Train 3D NEO": [
-        "BN3J"
-    ],
-    "A-Train 3D": [
-        "AALJ"
-    ],
-    "ACE COMBAT 3D\nCROSS RUMBLE": [
-        "AC3J"
-    ],
-    "ACE COMBAT\nAH LEGACY +": [
-        "BCRE",
-        "BCRP"
-    ],
-    "ACE COMBAT\nASSAULT HORIZON LEGACY": [
-        "AC3E",
-        "AC3P"
-    ],
-    "ACECOMBAT 3D\nCROSSRUMBLE +": [
-        "BCRJ"
-    ],
-    "AIKATSU! Cinderella Lesson": [
-        "AEKJ"
-    ],
-    "AKB48+Me": [
-        "AKBJ"
-    ],
-    "ALLIANCE ALIVE": [
-        "AL4J"
-    ],
-    "AT:  FJI": [
-        "BFNE",
-        "BFNP"
-    ],
-    "AZITO 3D": [
-        "AZTJ"
-    ],
-    "AZURE STRIKER GUNVOLT:\nSTRIKER PACK": [
-        "BG8E"
-    ],
-    "Adventure Time: ETDBIDK": [
-        "AY9E",
-        "AY9P"
-    ],
-    "Adventure Time: The Secret\nof the Nameless Kingd": [
-        "AVTE",
-        "AVTJ",
-        "AVTP"
-    ],
-    "Adventure Time\u2122 Hey Ice King!": [
-        "AD4E"
-    ],
-    "Alien Chaos 3D": [
-        "AM2E"
-    ],
-    "American Mensa Academy": [
-        "AMME"
-    ],
-    "Angler's Club\nUltimate Bass Fishing 3D": [
-        "AFDJ",
-        "AFDP"
-    ],
-    "Angry Birds Star Wars": [
-        "ANDE",
-        "ANDP"
-    ],
-    "Angry Birds Trilogy": [
-        "ANGE",
-        "ANGP"
-    ],
-    "Animal Crossing New Leaf": [
-        "EGDJ",
-        "EGDK"
-    ],
-    "Animal Crossing: New Leaf -\nWelcome amiibo": [
-        "EAAE",
-        "EAAJ",
-        "EAAP"
-    ],
-    "Animal Crossing: New Leaf": [
-        "EGDE",
-        "EGDP"
-    ],
-    "Animal Crossing:\nHappy Home Designer": [
-        "EDHE",
-        "EDHJ",
-        "EDHP"
-    ],
-    "Animal Hospital": [
-        "AZFP"
-    ],
-    "Anpanman to asobo\nnew aiueo kyoushitsu": [
-        "AEWJ"
-    ],
-    "Apollo Justice: Ace Attorney": [
-        "AXRJ"
-    ],
-    "Arcade Classics 3D": [
-        "ARDP"
-    ],
-    "Are You Smarter Than a\n5th Grader?": [
-        "BY5E"
-    ],
-    "Around the World with\nHello Kitty and Friends": [
-        "AHKP",
-        "AHKZ"
-    ],
-    "Art Academy\nLessons for Everyone!": [
-        "AACE"
-    ],
-    "Asphalt 3D: Nitro Racing": [
-        "ASFJ"
-    ],
-    "Asphalt 3D": [
-        "ASFE",
-        "ASFP"
-    ],
-    "Asterix\nThe Mansions of the Gods": [
-        "BMNP"
-    ],
-    "Atlantic Quest": [
-        "BAQP"
-    ],
-    "Atooi Collection": [
-        "AUTE"
-    ],
-    "Attack on Titan\nEscape from death": [
-        "AEVJ"
-    ],
-    "Azada": [
-        "AZDP"
-    ],
-    "BEASTSAGA": [
-        "BEAJ"
-    ],
-    "BEN 10 OMNIVERSE\u2122 2": [
-        "AEQE",
-        "AEQP"
-    ],
-    "BEN 10 OMNIVERSE\u2122": [
-        "ABVE",
-        "ABVP"
-    ],
-    "BEYBLADE EVOLUTION": [
-        "ARXE",
-        "ARXP",
-        "BBBJ"
-    ],
-    "BIOHAZARD\u00ae\nREVELATIONS": [
-        "ABRJ",
-        "ABRK",
-        "ABRW"
-    ],
-    "BIOHAZARD\u00ae\nTHE MERCENARIES 3D": [
-        "ABMJ"
-    ],
-    "BIT.TRIP SAGA": [
-        "ABTE",
-        "ABTP"
-    ],
-    "BLAZBLUE\nCONTINUUM SHIFT \u2161": [
-        "ABLJ",
-        "ABLP",
-        "ABLZ"
-    ],
-    "BRAVE COMPANY": [
-        "AYGJ"
-    ],
-    "BRAVELY DEFAULT": [
-        "BTRE",
-        "BTRP"
-    ],
-    "BRAVELY SECOND": [
-        "BSED",
-        "BSEE"
-    ],
-    "BUST-A-MOVE UNIVERSE": [
-        "ABBE"
-    ],
-    "Barbie Dreamhouse Party": [
-        "AAVE",
-        "AAVP"
-    ],
-    "Barbie and Her Sisters\nPuppy Rescue": [
-        "BRQE",
-        "BRQP",
-        "BRQZ"
-    ],
-    "Barbie\u2122\nGroom and Glam Pups\u2122": [
-        "ABYE",
-        "ABYP"
-    ],
-    "Batman\u2122:\nArkham Origins Blackgate": [
-        "AZEE",
-        "AZEP"
-    ],
-    "Battleship\u2122": [
-        "ABSE",
-        "ABSP"
-    ],
-    "Beautician debut story": [
-        "BYCJ"
-    ],
-    "Bella Sara 2\nThe Magic of Drasilmare": [
-        "AY7P"
-    ],
-    "Bella Sara\nThe Magical Horse Adventures": [
-        "AB2P"
-    ],
-    "Ben 10\u2122 Galactic Racing": [
-        "ABNE",
-        "ABNP"
-    ],
-    "Best Friends -\nMy Horse 3D": [
-        "BMEP"
-    ],
-    "Best of Arcade Games": [
-        "AYHP"
-    ],
-    "Best of Board Games": [
-        "AYFP"
-    ],
-    "Best of Casual Games": [
-        "BCSP"
-    ],
-    "Bibi Blocksberg - Das gro\u00dfe\nHexenbesen-Rennen 2": [
-        "AA3D"
-    ],
-    "Bibi&Tina\nDas Spiel zum Kinofilm": [
-        "BBTD"
-    ],
-    "BonBon Ribbon\nKiraKiraDance": [
-        "AVRJ"
-    ],
-    "Boulder Dash\u00ae-XL 3D\u2122": [
-        "ABZE",
-        "ABZP"
-    ],
-    "Bowling Bonanza 3D": [
-        "AB6P"
-    ],
-    "Brain Age\nConcentration Training": [
-        "ASRE"
-    ],
-    "Brain Training 3D": [
-        "AKTP"
-    ],
-    "Bratz\u00ae: Fashion Boutique": [
-        "AB5E"
-    ],
-    "Brilliant Hamsters!": [
-        "AHMJ"
-    ],
-    "Brunswick Pro Bowling": [
-        "ABWE"
-    ],
-    "CARDFIGHT!! Vanguard\nLOCK ON VICTORY!!": [
-        "BVGJ"
-    ],
-    "CARDFIGHT!! Vanguard\nRide To Victory!!": [
-        "AVGJ"
-    ],
-    "CODE OF PRINCESS": [
-        "AC7E",
-        "AC7J"
-    ],
-    "CONCEPTION\u2161\n\u4e03\u661f\u306e\u5c0e\u304d\u3068\u30de\u30ba\u30eb\u306e\u60aa\u5922": [
-        "BCCJ"
-    ],
-    "CRASH CITY MAYHEM": [
-        "AC2E"
-    ],
-    "CRAZY CONSTRUCTION": [
-        "BCZP"
-    ],
-    "CRUSH\u21223D": [
-        "ACRE",
-        "ACRJ",
-        "ACRP"
-    ],
-    "Candy Match 3": [
-        "BCMP"
-    ],
-    "Captain America\u2122: Super Soldier": [
-        "ACAE",
-        "ACAP"
-    ],
-    "Captain Toad: Treasure Tracker": [
-        "BZPE",
-        "BZPJ",
-        "BZPP"
-    ],
-    "Cardfight!! VanguardG\nSTRIDE TO VICTORY!!": [
-        "BCFJ"
-    ],
-    "Carnival Games\u00ae Wild West 3D": [
-        "AW2E"
-    ],
-    "Carnival Games\u2122 Wild West 3D": [
-        "AW2P"
-    ],
-    "Cars 2": [
-        "AAZE",
-        "AAZP",
-        "AAZZ"
-    ],
-    "Cartoon Network:Battle Crashers": [
-        "BRWE",
-        "BRWZ"
-    ],
-    "Cartoon Network\nPunch Time Explosion": [
-        "ACNE",
-        "ACNP"
-    ],
-    "Cartoonist debut story": [
-        "BGHJ"
-    ],
-    "Castlevania: Lords of Shadow\nMirror of Fate": [
-        "ACFE",
-        "ACFJ",
-        "ACFP"
-    ],
-    "Cats & Dogs\nPets at play": [
-        "AHUP"
-    ],
-    "Cave Story 3D": [
-        "ACVE",
-        "ACVP"
-    ],
-    "Centipede: Infestation": [
-        "ACPE"
-    ],
-    "Chara Pet": [
-        "BKPJ"
-    ],
-    "Chevrolet\u00aeCamaro\u2122Wild Ride 3D": [
-        "ACWP"
-    ],
-    "Chibi-Robo! Zip Lash": [
-        "BXLE",
-        "BXLJ",
-        "BXLP"
-    ],
-    "Classic Games Overload:\nCard & Puzzle Edition": [
-        "ACGE"
-    ],
-    "Cloudy with a Chance\nof Meatballs 2": [
-        "AD5E",
-        "AD5P",
-        "AD5Z"
-    ],
-    "Cocoto Alien Brick Breaker": [
-        "AB7P"
-    ],
-    "Code Name: S.T.E.A.M.": [
-        "AY6A"
-    ],
-    "Combat of Giants:\nDinosaurs 3D": [
-        "ATTE",
-        "ATTJ",
-        "ATTP"
-    ],
-    "Conan\u3000Marionettesymphony": [
-        "BKNJ"
-    ],
-    "Conception II:\nChildren of the Seven Stars": [
-        "BCCE"
-    ],
-    "Cooking Mama 5: Bon Appetit!": [
-        "BC5E"
-    ],
-    "Cooking Mama: Bon App\u00e9tit!": [
-        "BC5P"
-    ],
-    "Cooking Mama: Sweet Shop": [
-        "BS8E",
-        "BS8P"
-    ],
-    "Corpse Party": [
-        "BCPE"
-    ],
-    "Crash Time 3D": [
-        "AFBP"
-    ],
-    "Crosswords Plus": [
-        "AQ8E"
-    ],
-    "Cube Creator DX": [
-        "A9CJ"
-    ],
-    "Cubic Ninja": [
-        "AQNE",
-        "AQNJ",
-        "AQNP"
-    ],
-    "Culdcept Revolt": [
-        "AY3E",
-        "AY3J",
-        "AY3P"
-    ],
-    "Culdcept": [
-        "ACBJ"
-    ],
-    "Cut the Rope\u00ae\nTriple Treat": [
-        "BR3E",
-        "BR3P"
-    ],
-    "DEAD OR ALIVE Dimensions": [
-        "ADDE",
-        "ADDJ",
-        "ADDP"
-    ],
-    "DECA SPORTA\n3D SPORTS": [
-        "ADEJ"
-    ],
-    "DECA SPORTS EXTREME": [
-        "ADEE"
-    ],
-    "DETECTIVE CONAN\nPHANTOM RHAPSODY": [
-        "BKRJ"
-    ],
-    "DISNEY/PIXAR FINDING NEMO:\nESCAPE TO THE BIG BLU": [
-        "AF7P",
-        "AF7X"
-    ],
-    "DISNEY/PIXAR FINDING NEMO\nESCAPE TO THE BIG BLUE": [
-        "AF7E"
-    ],
-    "DQM2": [
-        "BDMJ"
-    ],
-    "DQMJOKER3 PRO": [
-        "BDQJ"
-    ],
-    "DQMJOKER3": [
-        "BJ3J"
-    ],
-    "DQMT": [
-        "ATWJ"
-    ],
-    "DRAGON BALL FUSIONS": [
-        "BDLE",
-        "BDLP"
-    ],
-    "DRAGON BALL Z:\nExtreme Butoden": [
-        "BDVE",
-        "BDVP"
-    ],
-    "DRAGON QUEST VII": [
-        "AD7E",
-        "AD7J",
-        "AD7P"
-    ],
-    "DRAGON QUEST XI": [
-        "BTZJ"
-    ],
-    "Deer Drive Legends": [
-        "AD2E"
-    ],
-    "Derby Stallion GOLD": [
-        "BDSJ"
-    ],
-    "Detective Pikachu": [
-        "A98A"
-    ],
-    "Devil Summoner: Soul Hackers": [
-        "AHQJ"
-    ],
-    "Devil Survivor 2:\nRecord Breaker": [
-        "ADXP"
-    ],
-    "Devil Survivor 2\nRecord Breaker": [
-        "ADXE"
-    ],
-    "Devilish Brain Training\nCan you stay focused?": [
-        "ASRP",
-        "ASRW"
-    ],
-    "Die drei ??? Kids\nJagd auf das Phantom": [
-        "BD4D"
-    ],
-    "Dillon's Dead-Heat Breakers": [
-        "A9EJ",
-        "A9EP"
-    ],
-    "Disney 2-Pack": [
-        "BF6Z"
-    ],
-    "Disney Art Academy": [
-        "BWDE",
-        "BWDJ",
-        "BWDP"
-    ],
-    "Disney Big Hero 6:\nBattle in the Bay": [
-        "BH6E",
-        "BH6P",
-        "BH6Z"
-    ],
-    "Disney Epic Mickey:\nPower of Illusion": [
-        "AECE",
-        "AECP",
-        "AECX"
-    ],
-    "Disney Frozen - Big Hero 6": [
-        "BF6E"
-    ],
-    "Disney Frozen: Olaf's Quest": [
-        "AEHE",
-        "AEHJ",
-        "AEHP"
-    ],
-    "Disney Frozen:\nOlaf\u2019s Quest": [
-        "AEHZ"
-    ],
-    "Disney Infinity:\nToy Box Challenge": [
-        "ADYE"
-    ],
-    "Disney Infinity": [
-        "ADYP",
-        "ADYZ"
-    ],
-    "Disney Magic Castle\nMy Happy Life": [
-        "AMQJ"
-    ],
-    "Disney Magical World 2": [
-        "BD2E",
-        "BD2P"
-    ],
-    "Disney Magical World": [
-        "AMQE",
-        "AMQP"
-    ],
-    "Disney Planes\nFire & Rescue": [
-        "BPRE",
-        "BPRP"
-    ],
-    "Disney Planes": [
-        "APNE",
-        "APNP",
-        "APNR",
-        "APNY",
-        "APNZ"
-    ],
-    "Disney Princess\nMy Fairytale Adventure": [
-        "ADPE",
-        "ADPP",
-        "ADPX"
-    ],
-    "Disney Princesses\nMon Royaume Enchant\u00e9": [
-        "ADPD"
-    ],
-    "Disney Violetta: Rhythm & Music": [
-        "BGRP"
-    ],
-    "Disney Wreck-It Ralph": [
-        "AWRE",
-        "AWRP"
-    ],
-    "Doctor Lautrec\nand the Forgotten Knights": [
-        "ADLE",
-        "ADLJ",
-        "ADLP"
-    ],
-    "DokiDoki! Precure": [
-        "BPQJ"
-    ],
-    "Dolly Kanon": [
-        "BJWJ"
-    ],
-    "Donkey Kong Returns 3D": [
-        "AYTJ"
-    ],
-    "Donkey Kong\nCountry Returns 3D": [
-        "AYTE",
-        "AYTP"
-    ],
-    "Dorachie": [
-        "BDCJ"
-    ],
-    "Doraeigo": [
-        "BDEJ"
-    ],
-    "Doraemon": [
-        "ADWW"
-    ],
-    "Doramoji": [
-        "BKVJ"
-    ],
-    "Downtown Nekketsu Jidaigeki": [
-        "BNJJ"
-    ],
-    "Dragon Ball Heroes\nUltimate Mission": [
-        "ADGJ"
-    ],
-    "Dragon Quest VIII": [
-        "BQ8E",
-        "BQ8J",
-        "BQ8P"
-    ],
-    "Dream Trigger\u2122 3D": [
-        "ADTE",
-        "ADTP"
-    ],
-    "DreamWorks Combo Pack": [
-        "AGCP"
-    ],
-    "DreamWorks\u00ae\nSuper Star Kartz\u2122": [
-        "AKZE",
-        "AKZP"
-    ],
-    "Driver\u00ae Renegade 3D": [
-        "ADRP"
-    ],
-    "Driver\u00ae Renegade": [
-        "ADRE"
-    ],
-    "DualPenSports": [
-        "APPE",
-        "APPP"
-    ],
-    "Duck Dynasty\u00ae": [
-        "BDKE"
-    ],
-    "Dynasty Warriors VS": [
-        "AS5J"
-    ],
-    "ESSE\u3089\u304f\u3089\u304f\u5bb6\u8a08\u7c3f": [
-        "AEZJ"
-    ],
-    "ETRIAN MYSTERY DUNGEON": [
-        "BFDE"
-    ],
-    "ETRIAN ODYSSEY V:\nBEYOND THE MYTH": [
-        "BMZP"
-    ],
-    "EXSTETRA": [
-        "BEXJ"
-    ],
-    "Earthpedia": [
-        "AEPJ"
-    ],
-    "El profesor Layton\ny el legado de los ashalanti": [
-        "AL6S"
-    ],
-    "El profesor Layton\ny la m\u00e1scara de los prodigios": [
-        "AKKS"
-    ],
-    "Elminage Gothic 3D REMIX\n-Ulm Zakiher and Dark R": [
-        "AEUJ"
-    ],
-    "Elminage Ibun\nAme no Mihashira Kai": [
-        "BAMJ"
-    ],
-    "Etrian Mystery Dungeon": [
-        "BFDP"
-    ],
-    "Etrian Odyssey 2 Untold:\nThe Fafnir Knight": [
-        "BM9E",
-        "BM9P"
-    ],
-    "Etrian Odyssey IV\nLegends of the Titan": [
-        "ASJE",
-        "ASJP"
-    ],
-    "Etrian Odyssey Nexus": [
-        "BZME",
-        "BZMP"
-    ],
-    "Etrian Odyssey Untold 2\nKnight of Fafnir": [
-        "BM9J"
-    ],
-    "Etrian Odyssey Untold\nMaiden of Millennium": [
-        "BSKJ"
-    ],
-    "Etrian Odyssey Untold\nThe Millennium Girl": [
-        "BSKE",
-        "BSKP"
-    ],
-    "Etrian Odyssey V:\nBeyond the Myth": [
-        "BMZE"
-    ],
-    "Etrian Odyssey V\nBeyond the Legends": [
-        "BMZJ"
-    ],
-    "Etrian Odyssey X": [
-        "BZMJ"
-    ],
-    "Ever Oasis": [
-        "BAGE",
-        "BAGJ",
-        "BAGP"
-    ],
-    "F1 2011": [
-        "AF4E",
-        "AF4J",
-        "AF4P"
-    ],
-    "FANTASY LIFE LINK!": [
-        "BLKJ"
-    ],
-    "FANTASY LIFE": [
-        "AFLJ"
-    ],
-    "FIFA 12": [
-        "AF2D",
-        "AF2P"
-    ],
-    "FIFA 13": [
-        "AF8D",
-        "AF8P"
-    ],
-    "FIFA 14": [
-        "AFYD",
-        "AFYP"
-    ],
-    "FIFA 15": [
-        "BFTD",
-        "BFTP"
-    ],
-    "FIFA Soccer 12": [
-        "AF2E"
-    ],
-    "FIFA Soccer 13": [
-        "AF8E"
-    ],
-    "FIFA Soccer 14": [
-        "AFYE"
-    ],
-    "FIFA Soccer 15": [
-        "BFTE"
-    ],
-    "FINAL FANTASY  EXPLORERS": [
-        "BCEJ"
-    ],
-    "FINAL FANTASY EXPLORERS": [
-        "BCEE",
-        "BCEP"
-    ],
-    "FIREMAN SAM\nTO THE RESCUE!": [
-        "AFTP"
-    ],
-    "FISH ON": [
-        "AFAJ"
-    ],
-    "FabStyle": [
-        "AFVJ"
-    ],
-    "Face Racers: Photo Finish": [
-        "AFCE"
-    ],
-    "Fantasy Life\u2122": [
-        "AFLE",
-        "AFLP"
-    ],
-    "Farming Simulator 14": [
-        "BFSE",
-        "BFSJ",
-        "BFSP"
-    ],
-    "Farming Simulator 18": [
-        "A8FE",
-        "A8FJ",
-        "A8FP"
-    ],
-    "Farming Simulator 2012 3D": [
-        "AL3P"
-    ],
-    "Farming Simulator 3D": [
-        "AL3J"
-    ],
-    "Farmscapes": [
-        "AF9F"
-    ],
-    "Fast & Furious\u2122: Showdown": [
-        "AFHE",
-        "AFHP"
-    ],
-    "Fate/kaleid liner\n\u30d7\u30ea\u30ba\u30de\u2606\u30a4\u30ea\u30e4": [
-        "AYLJ"
-    ],
-    "Fire Emblem Awakening": [
-        "AFEE"
-    ],
-    "Fire Emblem Echoes:\nShadows of Valentia": [
-        "AJJE",
-        "AJJJ",
-        "AJJK",
-        "AJJP"
-    ],
-    "Fire Emblem Fates\nBirthright": [
-        "BFXE",
-        "BFXP"
-    ],
-    "Fire Emblem Fates\nConquest": [
-        "BFYE",
-        "BFYP"
-    ],
-    "Fire Emblem Fates": [
-        "BFZE",
-        "BFZK",
-        "BFZP"
-    ],
-    "Fire Emblem if": [
-        "BFXZ"
-    ],
-    "Fire Emblem: Awakening": [
-        "AFEP"
-    ],
-    "Fish Eyes 3D": [
-        "ARFJ"
-    ],
-    "Flap Flap": [
-        "BFFP"
-    ],
-    "Fossil Fighters Frontier": [
-        "AHRD",
-        "AHRE"
-    ],
-    "Freakyforms Deluxe\nYour Creations, Alive!": [
-        "ATQE",
-        "ATQP"
-    ],
-    "Frogger 3D": [
-        "AFRE",
-        "AFRJ",
-        "AFRP"
-    ],
-    "Funassy VS Dragons": [
-        "BF4J"
-    ],
-    "Funfair Party Games": [
-        "AFND",
-        "AFNP"
-    ],
-    "Funky Barn 3D": [
-        "AFME",
-        "AFMJ",
-        "AFMP"
-    ],
-    "Future Card Buddyfight\nHead for BuddyChampion": [
-        "BFAJ"
-    ],
-    "Future Card Buddyfight\nHereComes OurStrongestBud": [
-        "BFBJ"
-    ],
-    "Future Card Buddyfight\nfriendship exploding figh": [
-        "BDYJ"
-    ],
-    "G1 Grand Prix": [
-        "AHTJ"
-    ],
-    "GAKI": [
-        "BDXJ"
-    ],
-    "GIRLS MODE 3\u3000\u30ad\u30e9\u30ad\u30e9\u2606\u30b3\u30fc\u30c7": [
-        "ECDJ"
-    ],
-    "GIRLS MODE\n\u3088\u304f\u3070\u308a\u5ba3\u8a00\uff01\u3000\u30c8\u30ad\u30e1\u30adUP\uff01": [
-        "ACLJ"
-    ],
-    "GUDETAMA2:": [
-        "BGJJ"
-    ],
-    "GUDETAMA:": [
-        "BGLJ"
-    ],
-    "GUILD01": [
-        "AG9J"
-    ],
-    "GUNDAM THE 3D BATTLE": [
-        "A78J"
-    ],
-    "GYROZETTER\nWings of Albaross": [
-        "ABCJ"
-    ],
-    "Gabrielle's Ghostly Groove 3D": [
-        "AG3E",
-        "AG3P"
-    ],
-    "Gaist Crusher God": [
-        "BGDJ"
-    ],
-    "Gaist Crusher": [
-        "AGYJ"
-    ],
-    "GameEhon_Adventure": [
-        "AY5J"
-    ],
-    "GameEhon_Princess": [
-        "AY4J"
-    ],
-    "Games Festival 1": [
-        "AAEP"
-    ],
-    "Games Festival 2": [
-        "AAFP"
-    ],
-    "Gardening Mama 2\nForest Friends": [
-        "BGME"
-    ],
-    "Gardening Mama\nMama and Her Forest Friends": [
-        "BGMJ"
-    ],
-    "Gardening mama\nForest Friends": [
-        "BGMP"
-    ],
-    "Gardenscapes": [
-        "AG8P"
-    ],
-    "Garfield Kart": [
-        "AGPE",
-        "AGPP"
-    ],
-    "Gem Smashers": [
-        "AGSE"
-    ],
-    "Generator Rex:\nAgent of Providence": [
-        "AGXE",
-        "AGXP"
-    ],
-    "Girls Mode 4\n\u30b9\u30bf\u30fc\u2606\u30b9\u30bf\u30a4\u30ea\u30b9\u30c8": [
-        "AJBJ"
-    ],
-    "Girls' Fashion Shoot": [
-        "ANLD",
-        "ANLE",
-        "ANLP"
-    ],
-    "GirlsRPG CindereLife": [
-        "ACJJ"
-    ],
-    "Goosebumps: The Game": [
-        "BBME",
-        "BBMP"
-    ],
-    "Gravity Falls": [
-        "AGFE",
-        "AGFP"
-    ],
-    "Green Lantern\u2122\nRise of the Manhunters": [
-        "AGLE",
-        "AGLP"
-    ],
-    "Gummy Bears\nMagical Medallion": [
-        "AGVP"
-    ],
-    "HATSUNE MIKU\nProject mirai 2": [
-        "AHNJ"
-    ],
-    "HATSUNE MIKU\nProject mirai": [
-        "AM9J"
-    ],
-    "HEAVY FIRE\nTHE CHOSEN FEW": [
-        "AHVJ"
-    ],
-    "HELLO KITTY 3D RACING": [
-        "BKYE",
-        "BKYP"
-    ],
-    "HYRULE WARRIORS LEGENDS": [
-        "BZHE",
-        "BZHJ",
-        "BZHP"
-    ],
-    "Hakuoki:\nMemories of the Shinsengumi": [
-        "AH9P"
-    ],
-    "Hakuoki\n~Memories of the Shinsengumi~": [
-        "AH9E"
-    ],
-    "Happy Feet 2": [
-        "AHFE",
-        "AHFP"
-    ],
-    "Harvest Moon:\nA New Beginning": [
-        "ABQE",
-        "ABQP"
-    ],
-    "Harvest Moon:\nSkytree Village": [
-        "AVAE",
-        "AVAP"
-    ],
-    "Harvest Moon:\nThe Lost Valley": [
-        "AVME",
-        "AVMP"
-    ],
-    "Harvest Moon\nThe Tale of Two Towns": [
-        "AT2E",
-        "AT2P"
-    ],
-    "Hatsune Miku:\nProject Mirai DX": [
-        "BRXE",
-        "BRXP"
-    ],
-    "Hatsune Miku\nProject Mirai DX": [
-        "BRXJ"
-    ],
-    "Heavy Fire:\nThe Chosen Few 3D": [
-        "AHVP"
-    ],
-    "Heavy Fire:\nThe Chosen Few": [
-        "AHVE"
-    ],
-    "Hello Kitty & Friends:\nRockin' World Tour": [
-        "BKTJ",
-        "BKTP"
-    ],
-    "Hello Kitty & the Apron of Magic\nRhythm Cooking\u266a": [
-        "BHKP"
-    ],
-    "Hello Kitty Picnic\nwith Sanrio Characters": [
-        "AHLD"
-    ],
-    "Hello Kitty Picnic\nwith Sanrio Friends": [
-        "AHLE"
-    ],
-    "Hello Kitty around the World": [
-        "AHKJ"
-    ],
-    "Hello Kitty\nHappy Happy Family": [
-        "BHHP"
-    ],
-    "Heroes of Ruin": [
-        "AH6E",
-        "AH6P"
-    ],
-    "Hey! Pikmin": [
-        "BRCE",
-        "BRCJ",
-        "BRCP"
-    ],
-    "Hidden Expedition\nTitanic": [
-        "AASP"
-    ],
-    "Hollywood Fame:\nHidden Object Adventure": [
-        "AFXP"
-    ],
-    "Hometown Story": [
-        "AHXE",
-        "AHXJ",
-        "AHXP"
-    ],
-    "Horrid Henry: The Good,\nThe Bad And The Bugly": [
-        "AHHP"
-    ],
-    "Horse Life 4": [
-        "BH4P"
-    ],
-    "Horse Vet 3D": [
-        "BP9P"
-    ],
-    "Horses 3D": [
-        "AHSE"
-    ],
-    "Hot Wheels\u2122 WBD": [
-        "AEAE",
-        "AEAP"
-    ],
-    "Hotel Transylvania": [
-        "AH8E",
-        "AH8F",
-        "AH8P"
-    ],
-    "How to Train Your Dragon 2": [
-        "BTDE",
-        "BTDP"
-    ],
-    "HyakumasuDorazan\nNobitaNoTimeBattle": [
-        "BNHJ"
-    ],
-    "I Love My Cats": [
-        "ALKP"
-    ],
-    "I Love My Dogs": [
-        "ALWP"
-    ],
-    "I Love My Horse": [
-        "BMHP"
-    ],
-    "I Love My Little Boy": [
-        "BLBP"
-    ],
-    "I Love My Little Girl": [
-        "BLGP"
-    ],
-    "I Love My Pets": [
-        "AA6P"
-    ],
-    "I Love My Pony": [
-        "ALNP"
-    ],
-    "Ice Age\u2122 4\nArctic Games": [
-        "AQLP"
-    ],
-    "Ice Age\u2122\nArctic Games": [
-        "AQLE"
-    ],
-    "Il professor Layton\ne la maschera dei miracoli": [
-        "AKKI"
-    ],
-    "Il professor Layton\ne l\u2019eredit\u00e0 degli Aslant": [
-        "AL6I"
-    ],
-    "Imagine Champion Rider 3D": [
-        "AHSP"
-    ],
-    "Imagine\u00ae Collection": [
-        "BCLP"
-    ],
-    "Imagine\u00ae\nbabyz\u00ae": [
-        "ABAE"
-    ],
-    "Imagine\u2122\nBabies 3D": [
-        "ABAP"
-    ],
-    "Imagine\u2122\nFashion Designer 3D": [
-        "AGUP"
-    ],
-    "Imagine\u2122\nFashion Designer": [
-        "AGUE"
-    ],
-    "Imagine\u2122\nFashion Life": [
-        "AF3E"
-    ],
-    "Imagine\u2122\nFashion World 3D": [
-        "AF3P"
-    ],
-    "Inazuma Eleven 3\nBomb Blast": [
-        "AXBP",
-        "AXBZ"
-    ],
-    "Inazuma Eleven 3\nLightning Bolt": [
-        "AXSP",
-        "AXSZ"
-    ],
-    "Inazuma Eleven 3\nTeam Ogre Attacks!": [
-        "AXGP",
-        "AXGZ"
-    ],
-    "Inazuma Eleven GO\nChrono Stones: Thunderflash": [
-        "ARAP"
-    ],
-    "Inazuma Eleven GO\nChrono Stones: Wildfire": [
-        "ANPP"
-    ],
-    "Inazuma Eleven GO\nLight": [
-        "AE4P"
-    ],
-    "Inazuma Eleven GO\nShadow": [
-        "AEDP"
-    ],
-    "IslandDays": [
-        "BDZJ"
-    ],
-    "JAWS: Ultimate Predator": [
-        "AJWE"
-    ],
-    "JS-Girl Doki Doki\nModel Challenge": [
-        "BJSJ"
-    ],
-    "Jake Hunter\nGHOST OF THE DUSK": [
-        "BG9E"
-    ],
-    "James Noir's Hollywood Crimes": [
-        "AHCE"
-    ],
-    "James Noir's\nHollywood Crimes 3D": [
-        "AHCP"
-    ],
-    "Jet Dog": [
-        "AJTP"
-    ],
-    "Jewel Link Double Pack\nAtlantic Quest / Safari Q": [
-        "BJLP"
-    ],
-    "Jewel Link\nLegends of Atlantis": [
-        "AJ5P"
-    ],
-    "Jewel Master Atlantis 3D": [
-        "AJ5X"
-    ],
-    "Jewel Master\nCradle of Egypt 2 3D": [
-        "AJEE",
-        "AJEF",
-        "AJEP"
-    ],
-    "Jewel Master\nCradle of Rome 2": [
-        "AJLE",
-        "AJLP",
-        "AJLZ"
-    ],
-    "Jewel Match 3": [
-        "AJUP"
-    ],
-    "Jewel Quest Heritage": [
-        "AJ4P"
-    ],
-    "Jewel Quest Mysteries\nThe Seventh Gate": [
-        "AJQP"
-    ],
-    "JewelPet 3DS": [
-        "AJPJ"
-    ],
-    "JewelQuest 6": [
-        "AJ6P"
-    ],
-    "Jewelpet 3DS 2": [
-        "AJYJ"
-    ],
-    "Jewelpet 3DS 6": [
-        "BJPJ"
-    ],
-    "Junior Classic Games": [
-        "AJCE"
-    ],
-    "Junior Games 3D": [
-        "AJCP"
-    ],
-    "KAWAII KONEKO 3D": [
-        "AKCJ"
-    ],
-    "KINGDOM HEARTS 3D\n[Dream Drop Distance]": [
-        "AKHE",
-        "AKHJ",
-        "AKHP"
-    ],
-    "KOBITO GAME TAIZEN": [
-        "BK3J"
-    ],
-    "KOKUGA": [
-        "AK8J"
-    ],
-    "KONEKO NO ALBUM": [
-        "BLCJ"
-    ],
-    "KaiteoboeruDoragana": [
-        "BDAJ"
-    ],
-    "Kamiwazawanda\nKirakiraichibangai Kikiippatsu!": [
-        "AWFJ"
-    ],
-    "Karous\n- The Beast Of Re\uff1aEden -": [
-        "BKEJ"
-    ],
-    "KasekiHorider MugenGear": [
-        "AHRJ"
-    ],
-    "KenkaBancho6\nsoul&blood": [
-        "BC6J"
-    ],
-    "Kid Icarus: Uprising": [
-        "AKDE",
-        "AKDJ",
-        "AKDP"
-    ],
-    "Kirby Battle Royale": [
-        "AJ8E",
-        "AJ8J",
-        "AJ8P"
-    ],
-    "Kirby's Extra Epic Yarn": [
-        "BE4E",
-        "BE4J",
-        "BE4P"
-    ],
-    "Kirby: Planet Robobot": [
-        "AT3A",
-        "AT3K"
-    ],
-    "Kirby: Triple Deluxe": [
-        "BALE",
-        "BALJ",
-        "BALK",
-        "BALP"
-    ],
-    "Konchu monster\nsuper battle": [
-        "BUXJ"
-    ],
-    "Kumamon\u2605Bomber\nPuzzle de Kumamontaisou": [
-        "BKMJ"
-    ],
-    "Kung Fu Panda: SLL": [
-        "BKFE",
-        "BKFP"
-    ],
-    "Kunio-kun nekketsu complete\nfamicom edition": [
-        "BKCJ"
-    ],
-    "Kuniokun SP Ranto Kyosokyoku": [
-        "AK2J",
-        "AK2K"
-    ],
-    "Kuniokun Special": [
-        "AK9K"
-    ],
-    "LAYTON'S MYSTERY JOURNEY\nKatrielle and the Milli": [
-        "BLFJ"
-    ],
-    "LAYTON'S MYSTERY JOURNEY\u2122\nKatrielle and the Mill": [
-        "BLFE",
-        "BLFP"
-    ],
-    "LEGO\u00ae Batman\u2122 2:\nDC Super Heroes": [
-        "ALBD",
-        "ALBE",
-        "ALBF",
-        "ALBP"
-    ],
-    "LEGO\u00ae Batman\u2122 3\nBeyond Gotham": [
-        "BTME",
-        "BTMJ",
-        "BTMP",
-        "BTMV",
-        "BTMX",
-        "BTMY",
-        "BTMZ"
-    ],
-    "LEGO\u00ae City Undercover:\nThe Chase Begins": [
-        "AA8E",
-        "AA8J",
-        "AA8P"
-    ],
-    "LEGO\u00ae Friends": [
-        "AZJE",
-        "AZJP"
-    ],
-    "LEGO\u00ae Harry Potter\u2122:\nYears 5-7": [
-        "AHPE",
-        "AHPP"
-    ],
-    "LEGO\u00ae Jurassic World": [
-        "BLJJ"
-    ],
-    "LEGO\u00ae Jurassic World\u2122": [
-        "BLJE",
-        "BLJP",
-        "BLJV",
-        "BLJX",
-        "BLJY",
-        "BLJZ"
-    ],
-    "LEGO\u00ae Legends of Chima\u2122": [
-        "APRE",
-        "APRP"
-    ],
-    "LEGO\u00ae MARVEL's\nAvengers": [
-        "ALEE",
-        "ALEJ",
-        "ALEP",
-        "ALEV",
-        "ALEX",
-        "ALEY",
-        "ALEZ"
-    ],
-    "LEGO\u00ae Marvel\u2122 Super Heroes\nUniverse in Peril": [
-        "AL5D",
-        "AL5E",
-        "AL5F",
-        "AL5J",
-        "AL5P",
-        "AL5S",
-        "AL5Y"
-    ],
-    "LEGO\u00ae Ninjago\u2122:\nShadow of Ronin": [
-        "BLSE"
-    ],
-    "LEGO\u00ae Ninjago\u2122\nNindroids\u2122": [
-        "BLNE",
-        "BLNJ",
-        "BLNP",
-        "BLNX",
-        "BLNY",
-        "BLNZ"
-    ],
-    "LEGO\u00ae Pirates of the Caribbean\nThe Video Game": [
-        "APCE",
-        "APCP"
-    ],
-    "LEGO\u00ae STAR WARS\u2122:\nThe Force Awakens": [
-        "BLWD",
-        "BLWE",
-        "BLWF",
-        "BLWI",
-        "BLWJ",
-        "BLWP",
-        "BLWS"
-    ],
-    "LEGO\u00ae StarWars\u00ae III:\nThe Clone Wars\u2122": [
-        "ALGE"
-    ],
-    "LEGO\u00ae StarWars\u2122 III:\nThe Clone Wars\u2122": [
-        "ALGP"
-    ],
-    "LEGO\u00ae The Hobbit\u2122": [
-        "BLHE",
-        "BLHP",
-        "BLHX",
-        "BLHY",
-        "BLHZ"
-    ],
-    "LEGO\u00ae The Lord of the Rings\u2122": [
-        "ALAD",
-        "ALAE",
-        "ALAF",
-        "ALAP",
-        "ALAS"
-    ],
-    "LEGO\u00aeNinjago\u2122:\nShadow of Ronin": [
-        "BLSJ",
-        "BLSP",
-        "BLSX",
-        "BLSY",
-        "BLSZ"
-    ],
-    "La Corda d'Oro3\nFullvoice Special": [
-        "BC3J"
-    ],
-    "Lalaloopsy\u2122:\nCarnival of Friends": [
-        "ALYE"
-    ],
-    "Langrisser Re:Incarnation\n-TENSEI-": [
-        "BRGE"
-    ],
-    "Legend of Legacy": [
-        "BLLJ"
-    ],
-    "Legends Of Oz:\nDorothy's Return": [
-        "BDTE",
-        "BDTP"
-    ],
-    "Let's Ride\nBest in Breed 3D\u2122": [
-        "ALDE"
-    ],
-    "Life with Horses 3D": [
-        "BMGP"
-    ],
-    "Little Battlers eXperience": [
-        "ADNE",
-        "ADNP",
-        "ADNZ"
-    ],
-    "Lord of Magna: Maiden Heaven": [
-        "BKKE"
-    ],
-    "Lucky Luke & The Daltons": [
-        "ALJP"
-    ],
-    "Luigi's Mansion 2": [
-        "AGGP",
-        "AGGW"
-    ],
-    "Luigi's Mansion: Dark Moon": [
-        "AGGE"
-    ],
-    "Luigi's Mansion": [
-        "BGNE",
-        "BGNJ",
-        "BGNP"
-    ],
-    "Luv Me Buddies Wonderland": [
-        "BWLP"
-    ],
-    "Luxor": [
-        "ALXP"
-    ],
-    "L\u2019ERA GLACIALE\u2122 4\nGIOCHI POLARI": [
-        "AQLI"
-    ],
-    "M & S at the London 2012\nOlympic Games": [
-        "ACME",
-        "ACMK",
-        "ACMP"
-    ],
-    "M & S at the Rio 2016\nOlympic Games": [
-        "BGXE",
-        "BGXJ",
-        "BGXP"
-    ],
-    "MAHJONG CUB3D": [
-        "ASHE"
-    ],
-    "MAJIN BONE": [
-        "BZRJ"
-    ],
-    "MARIO KART 7": [
-        "AMKE",
-        "AMKK",
-        "AMKP",
-        "AMKW"
-    ],
-    "MEDAROT7\nKABUTO Ver.": [
-        "AQBJ"
-    ],
-    "MEDAROT7\nKUWAGATA Ver.": [
-        "AQWJ"
-    ],
-    "MEDAROT8\nKABUTO Ver.": [
-        "BMKJ"
-    ],
-    "MEDAROT8\nKUWAGATA Ver.": [
-        "BMQJ"
-    ],
-    "MEDAROT9\nKABUTO Ver.": [
-        "BA9J"
-    ],
-    "MEDAROT9\nKUWAGATA Ver.": [
-        "BB9J"
-    ],
-    "METAL GEAR SOLID\nSNAKE EATER 3D": [
-        "AMGE",
-        "AMGJ",
-        "AMGP"
-    ],
-    "METALMAX4\nDiva of The Moonlight": [
-        "AX4J"
-    ],
-    "METROID PRIME\nFEDERATION FORCE": [
-        "BCAE",
-        "BCAJ",
-        "BCAP"
-    ],
-    "METROID\nSamus Returns": [
-        "A9AE",
-        "A9AJ",
-        "A9AP"
-    ],
-    "MIKE THE KNIGHT": [
-        "BMJP"
-    ],
-    "MOKOMOKO FRIENDS": [
-        "BM5J"
-    ],
-    "MONSTER HUNTER 3 (tri-) G": [
-        "AMHJ"
-    ],
-    "MONSTER HUNTER 3 ULTIMATE": [
-        "AMHE",
-        "AMHP"
-    ],
-    "MONSTER HUNTER 4 ULTIMATE": [
-        "BFGE",
-        "BFGP"
-    ],
-    "MONSTER HUNTER 4G": [
-        "BFGJ",
-        "BFGZ"
-    ],
-    "MONSTER HUNTER 4": [
-        "AH4J",
-        "AH4K",
-        "AH4Z"
-    ],
-    "MONSTER HUNTER STORIES": [
-        "AAHE",
-        "AAHJ",
-        "AAHP"
-    ],
-    "MONSTER HUNTER XX": [
-        "AGQJ"
-    ],
-    "MONSTER HUNTER X": [
-        "BXXJ"
-    ],
-    "MONSTER HUNTER\nGENERATIONS": [
-        "BXXE",
-        "BXXP"
-    ],
-    "MYST": [
-        "AM7E",
-        "AM7P"
-    ],
-    "Madagascar 3": [
-        "AMCE",
-        "AMCJ",
-        "AMCP"
-    ],
-    "Madden NFL Football": [
-        "AMDE",
-        "AMDP"
-    ],
-    "Mahjong 3D\nWarriors of the Emperor": [
-        "AMZE",
-        "AMZP"
-    ],
-    "Mahjong Mysteries\nAncient Athena 3D": [
-        "AM5P"
-    ],
-    "Mahjongg Mysteries\nAncient Athena 3D": [
-        "AM5Z"
-    ],
-    "Maple Story": [
-        "BMPJ",
-        "BMPK"
-    ],
-    "Mario & Luigi: Bowser's Inside\nStory + Bowser Jr": [
-        "A3RE",
-        "A3RJ",
-        "A3RP"
-    ],
-    "Mario & Luigi: Paper Jam Bros.": [
-        "AYNP"
-    ],
-    "Mario & Luigi: Paper Jam": [
-        "AYNE",
-        "AYNJ"
-    ],
-    "Mario & Luigi: Superstar Saga\n+ Bowser's Minions": [
-        "BRME",
-        "BRMJ",
-        "BRMP"
-    ],
-    "Mario & Luigi\nDream Team Bros.": [
-        "AYMP"
-    ],
-    "Mario & Luigi\nDream Team": [
-        "AYME"
-    ],
-    "Mario Golf: World Tour": [
-        "AJ3E",
-        "AJ3J",
-        "AJ3P"
-    ],
-    "Mario Party: Island Tour": [
-        "ATSE",
-        "ATSJ",
-        "ATSP"
-    ],
-    "Mario Party: Star Rush": [
-        "BAAE",
-        "BAAJ",
-        "BAAP"
-    ],
-    "Mario Party: The Top 100": [
-        "BHRE",
-        "BHRJ",
-        "BHRP"
-    ],
-    "Mario Sports Superstars": [
-        "AUNE",
-        "AUNJ",
-        "AUNP"
-    ],
-    "Mario Tennis Open": [
-        "AGAE",
-        "AGAJ",
-        "AGAP",
-        "AGAW"
-    ],
-    "Mario vs. Donkey Kong\nTipping Stars": [
-        "JYLJ"
-    ],
-    "Mario&Luigi RPG4\nDreamAdventure": [
-        "AYMJ"
-    ],
-    "Marvel Super Hero Squad\nThe Infinity Gauntlet": [
-        "AMSE",
-        "AMSP"
-    ],
-    "Me & My Pets 3D": [
-        "BM3P"
-    ],
-    "Me & My furry Patients 3D": [
-        "BMTP"
-    ],
-    "Medarot DUAL\nKABUTO Ver.": [
-        "AQVJ"
-    ],
-    "Medarot DUAL\nKUWAGATA Ver.": [
-        "AQAJ"
-    ],
-    "Medarot Girls Mission\nKABUTO Ver.": [
-        "BGPJ"
-    ],
-    "Medarot Girls Mission\nKUWAGATA Ver.": [
-        "BGQJ"
-    ],
-    "Mega Man Legacy Collection": [
-        "BMME",
-        "BMMJ"
-    ],
-    "Mensa Academy": [
-        "AMMP"
-    ],
-    "Michael Jackson\nThe Experience 3D": [
-        "AMJE",
-        "AMJP"
-    ],
-    "Miitopia": [
-        "ADQE",
-        "ADQJ",
-        "ADQP"
-    ],
-    "Moco Moco Friends": [
-        "BM5E"
-    ],
-    "Monster 4X4 3D": [
-        "AM4E",
-        "AM4P"
-    ],
-    "Monster High -\nNew Ghoul in School": [
-        "BMSE",
-        "BMSP"
-    ],
-    "Monster High\u2122: 13 Wishes": [
-        "AEFP",
-        "AEFZ"
-    ],
-    "Monster High\u2122: 13 Wishes\u2122": [
-        "AEFE"
-    ],
-    "Monster High\u2122\nSkultimate Roller Maze": [
-        "AH5P"
-    ],
-    "Monster High\u2122\nSkultimate Roller Maze\u2122": [
-        "AH5E"
-    ],
-    "Moshi Monsters\u2122\nKatsuma Unleashed": [
-        "ADME",
-        "ADMP"
-    ],
-    "Moshi Monsters\u2122\nMoshlings\u2122 Theme Park": [
-        "AA9E",
-        "AA9P"
-    ],
-    "Movie Player": [
-        "AABP"
-    ],
-    "Murder on the Titanic": [
-        "AM8P"
-    ],
-    "Mushibugyo": [
-        "BMBJ"
-    ],
-    "My Baby Pet Hotel 3D": [
-        "AEYP"
-    ],
-    "My Exotic Farm": [
-        "ABUP"
-    ],
-    "My Farm 3D": [
-        "ANJP"
-    ],
-    "My Foal 3D": [
-        "AM3Z"
-    ],
-    "My Life on a farm 3D": [
-        "BHFP"
-    ],
-    "My Little Baby 3D": [
-        "AYYP"
-    ],
-    "My Melody": [
-        "BM7J"
-    ],
-    "My Pet Puppy 3D": [
-        "AMYE",
-        "APYJ"
-    ],
-    "My Pet School 3D": [
-        "BM6P"
-    ],
-    "My Vet Practice 3D\nIn the country": [
-        "AERP"
-    ],
-    "My Western Horse 3D": [
-        "AZHP"
-    ],
-    "My Zoo Vet\nPractice 3D": [
-        "ATXP"
-    ],
-    "Mystery Case Files:\nDire Grove": [
-        "ADHP"
-    ],
-    "Mystery Case Files:\nRavenhearst": [
-        "AAQP"
-    ],
-    "Mystery Case Files:\nReturn to Ravenhearst": [
-        "AR2P"
-    ],
-    "Mystery Murders:\nJack the Ripper": [
-        "AAJP"
-    ],
-    "NANO ASSAULT": [
-        "AN3J"
-    ],
-    "NARUTO Powerful Shippuden": [
-        "AN4E",
-        "AN4P"
-    ],
-    "NARUTO SHIPPUDEN 3D\nThe New ERA": [
-        "ANTF",
-        "ANTP"
-    ],
-    "NARUTO-\u30ca\u30eb\u30c8- \u75be\u98a8\u4f1d\n\u5fcd\u7acb\u4f53\u7d75\u5dfb\uff01\u6700\u5f37\u5fcd\u754c\u6c7a\u6226\uff01\uff01": [
-        "ANTJ"
-    ],
-    "NASCAR\u00ae Unleashed": [
-        "AC9E"
-    ],
-    "NCIS\u2122 3D\nBASED ON THE TV SERIES": [
-        "ANCE",
-        "ANCP"
-    ],
-    "NEW\u30e9\u30d6\u30d7\u30e9\u30b9": [
-        "ALPJ"
-    ],
-    "NEW\u30e9\u30d6\u30d7\u30e9\u30b9\uff0b": [
-        "BLPJ"
-    ],
-    "Nano Assault": [
-        "AN3E"
-    ],
-    "Navy Commander": [
-        "BNCP"
-    ],
-    "Need For Speed\u2122 The Run": [
-        "ANSE",
-        "ANSJ",
-        "ANSP"
-    ],
-    "Nekketsu Monogatari Special": [
-        "BDJJ"
-    ],
-    "New Art Academy": [
-        "AACJ",
-        "AACP"
-    ],
-    "New Atelier Rorona\nStory of the beginning": [
-        "BRAJ"
-    ],
-    "New SUPER MARIO BROS. 2": [
-        "ABEJ",
-        "ABEP",
-        "ABEW"
-    ],
-    "New Super Mario Bros. 2": [
-        "ABEE"
-    ],
-    "Nicktoons MLB\u00ae 3D": [
-        "ANKE"
-    ],
-    "Nikoli's Pencil Puzzle": [
-        "AS9E",
-        "AS9J"
-    ],
-    "Nintendo 3DS Guide: Louvre\n(Deutsche Version)": [
-        "AL8D"
-    ],
-    "Nintendo 3DS Guide: Louvre\n(English Version)": [
-        "AL8P"
-    ],
-    "Nintendo 3DS Guide: Louvre\n(Version fran\u00e7aise)": [
-        "AL8F"
-    ],
-    "Nintendo 3DS Guide: Louvre\n(Versione italiana)": [
-        "AL8I"
-    ],
-    "Nintendo 3DS Guide: Louvre\n(versi\u00f3n en espa\u00f1ol)": [
-        "AL8S"
-    ],
-    "Nintendo 3DS Guide: Louvre": [
-        "AL8J",
-        "AL8K"
-    ],
-    "Nintendo Presents\nNew Style Boutique 3": [
-        "AJBP"
-    ],
-    "Nintendo presents:\nNew Style Boutique": [
-        "ACLP"
-    ],
-    "Nintendo presents\nNew Style Boutique 2": [
-        "ECDP"
-    ],
-    "Nintendo presents\nStyle Savvy: Fashion Forward": [
-        "ECDE"
-    ],
-    "Nobunaga's Ambition 2": [
-        "BNYJ"
-    ],
-    "Nobunaga's Ambition": [
-        "BNBJ"
-    ],
-    "ONE PIECE\nROMANCE DAWN": [
-        "BRDP",
-        "BRDZ"
-    ],
-    "ONE PIECE\nUNLIMITED WORLD R": [
-        "BUWJ"
-    ],
-    "ONE PIECE\nUnlimited World Red": [
-        "BUWE",
-        "BUWP"
-    ],
-    "ONE PIECE\n\u5927\u6d77\u8cca\u95d8\u6280\u5834": [
-        "BUZJ"
-    ],
-    "OSYARENA KOINU 3D": [
-        "AYUJ"
-    ],
-    "Ocha-Ken To Itsumo Nakayoshi": [
-        "AE3J"
-    ],
-    "One Piece\nUnlimited Cruise SP 2": [
-        "AL9P"
-    ],
-    "One Piece\nUnlimited Cruise SP": [
-        "ALFP"
-    ],
-    "Order Up!!": [
-        "AUPP"
-    ],
-    "Oregon Trail": [
-        "AT9E"
-    ],
-    "Oshaberi Usagi": [
-        "AUGJ"
-    ],
-    "Outback Pet\nRescue 3D": [
-        "BM4P"
-    ],
-    "Outdoors Unleashed\nAfrica 3D": [
-        "AFKP"
-    ],
-    "Oxford Reading Tree\nFloppy's Phonics vol.1": [
-        "AFZJ"
-    ],
-    "Oxford Reading Tree\nFloppy's Phonics vol.2": [
-        "AX2J"
-    ],
-    "Oxford Reading Tree\nFloppy's Phonics vol.3": [
-        "AX3J"
-    ],
-    "PAC-MAN GHOSTLY ADV 2": [
-        "BPME",
-        "BPMJ",
-        "BPMP"
-    ],
-    "PAC-MAN PARTY 3D": [
-        "AP9E",
-        "AP9J",
-        "AP9P"
-    ],
-    "PAC-MAN\u2122\nand the Ghostly Adventures": [
-        "AEJE",
-        "AEJJ",
-        "AEJP"
-    ],
-    "PAPER MARIO\nSticker Star": [
-        "AG5E",
-        "AG5J",
-        "AG5K",
-        "AG5P",
-        "AG5W"
-    ],
-    "PERSONAQ2\nNEW CINEMA LABYRINTH": [
-        "AQ2J"
-    ],
-    "PERSONAQ\nSHADOW OF THE LABYRINTH": [
-        "AQQJ"
-    ],
-    "PES 2011 3D": [
-        "AEEI",
-        "AEEP"
-    ],
-    "PES 2012 3D": [
-        "AE2D",
-        "AE2I",
-        "AE2P"
-    ],
-    "PES 2013 3D": [
-        "AWTD",
-        "AWTI",
-        "AWTP"
-    ],
-    "POMPOMPURIN\nKoroKoro Adventures": [
-        "BP6J"
-    ],
-    "POYOPOYO": [
-        "AP4J"
-    ],
-    "PROFESSIONAL BASEBALL SPIRITS 2011": [
-        "APSJ"
-    ],
-    "PROFESSOR LAYTON\nVS ACE ATTORNEY": [
-        "AVSJ"
-    ],
-    "PROJECT CROSS ZONE 2 ": [
-        "BX2K"
-    ],
-    "PROJECT X ZONE 2\nBRAVE NEW WORLD": [
-        "BX2J"
-    ],
-    "PROJECT X ZONE 2\nORIGINAL GAME SOUND": [
-        "BXPJ"
-    ],
-    "PROJECT X ZONE 2": [
-        "BX2E",
-        "BX2P"
-    ],
-    "PROJECT X ZONE": [
-        "AXXJ"
-    ],
-    "PUZZLE & DRAGONS CROSS\nDRAGON type": [
-        "BPVJ"
-    ],
-    "PUZZLE & DRAGONS CROSS\nGOD type": [
-        "BPWJ"
-    ],
-    "PUZZLE & DRAGONS\nSUPER MARIO BROS. EDITION": [
-        "AZMJ"
-    ],
-    "PUZZLE BOBBLE UNIVERSE": [
-        "ABBP"
-    ],
-    "Pac-Man & Galaga\nDimensions": [
-        "APGE",
-        "APGJ",
-        "APGP"
-    ],
-    "Paddington:\nAdventures in London": [
-        "BPLE",
-        "BPLP"
-    ],
-    "Paws & Claws\nPampered Pets Resort 3D": [
-        "AP8E"
-    ],
-    "Pazuru": [
-        "BPZP"
-    ],
-    "Persona Q2\nNew Cinema Labyrinth": [
-        "AQ2E",
-        "AQ2P"
-    ],
-    "Persona Q:\nShadow of the Labyrinth": [
-        "AQQE",
-        "AQQP"
-    ],
-    "PersonaQ\nShadow Of The Labyrinth": [
-        "AQQK"
-    ],
-    "Pet Zombies": [
-        "APZE"
-    ],
-    "Pets Resort 3D": [
-        "AP3P"
-    ],
-    "Petz Fantasy 3D": [
-        "APFE",
-        "APFP"
-    ],
-    "Petz\u00ae\nBeach": [
-        "APIE",
-        "APIP"
-    ],
-    "Petz\u00ae\nCountryside": [
-        "APOE",
-        "APOP"
-    ],
-    "Phineas & Ferb:\nQuest For Cool Stuff": [
-        "AAWE",
-        "AAWP"
-    ],
-    "Phoenix Wright: Ace Attorney\nSpirit of Justice": [
-        "BG6J"
-    ],
-    "Phonics Fun with Biff,\nChip and Kipper vol.1": [
-        "AFZP"
-    ],
-    "Phonics Fun with Biff,\nChip and Kipper vol.2": [
-        "AX2P"
-    ],
-    "Phonics Fun with Biff,\nChip and Kipper vol.3": [
-        "AX3P"
-    ],
-    "Picross 3D: Round 2": [
-        "BBPP"
-    ],
-    "Pilotwings Resort": [
-        "AWAE",
-        "AWAJ",
-        "AWAP"
-    ],
-    "Pinball Hall of Fame:\nThe Williams Collection 3D": [
-        "APBE",
-        "APBP"
-    ],
-    "Pippi Longstocking 3D": [
-        "APEP"
-    ],
-    "Pok\u00e9mon Alpha Sapphire": [
-        "ECLA"
-    ],
-    "Pok\u00e9mon Art Academy": [
-        "BPCE",
-        "BPCJ",
-        "BPCP"
-    ],
-    "Pok\u00e9mon Moon": [
-        "BNEA"
-    ],
-    "Pok\u00e9mon Mystery Dungeon\nGates to Infinity": [
-        "APDE",
-        "APDP"
-    ],
-    "Pokemon Mystery Dungeon\nMagna gate and infinity ": [
-        "APDJ"
-    ],
-    "Pok\u00e9mon Omega Ruby": [
-        "ECRA"
-    ],
-    "Pok\u00e9mon Rumble Blast": [
-        "ACCE"
-    ],
-    "Pok\u00e9mon Rumble World": [
-        "ECFA"
-    ],
-    "Pok\u00e9mon Sun": [
-        "BNDA"
-    ],
-    "Pok\u00e9mon Ultra Moon": [
-        "A2BA"
-    ],
-    "Pok\u00e9mon Ultra Sun": [
-        "A2AA"
-    ],
-    "Pok\u00e9mon X": [
-        "EKJA"
-    ],
-    "Pok\u00e9mon Y": [
-        "EK2A"
-    ],
-    "Pok\u00e9mon\nSuper Mystery Dungeon": [
-        "BPXE",
-        "BPXJ",
-        "BPXP"
-    ],
-    "Poochy & Yoshi's Woolly World": [
-        "AJNE",
-        "AJNJ",
-        "AJNP"
-    ],
-    "Poptropica: Forgotten Islands": [
-        "BPFE"
-    ],
-    "Power Rangers\nMegaforce": [
-        "AZBE",
-        "AZBP"
-    ],
-    "Power Rangers\nSuper Megaforce": [
-        "BSSE",
-        "BSSP"
-    ],
-    "PriPri Chi-chan!!\nPriPri Decoroom": [
-        "B2CJ"
-    ],
-    "Pro Evolution Soccer 2011 3D": [
-        "AEEE"
-    ],
-    "Pro Evolution Soccer 2012 3D": [
-        "AE2E"
-    ],
-    "Pro Evolution Soccer 2013 3D": [
-        "AWTE"
-    ],
-    "Professeur Layton\net le masque des miracles": [
-        "AKKF"
-    ],
-    "Professeur Layton\net l\u2019h\u00e9ritage des Aslantes": [
-        "AL6F"
-    ],
-    "Professional Baseball\nFamista2011": [
-        "AFSJ"
-    ],
-    "Professor Layton vs\nPhoenix Wright: Ace Attorney": [
-        "AVSE",
-        "AVSP",
-        "AVSZ"
-    ],
-    "Professor Layton\nand the Azran Legacy": [
-        "AL6E",
-        "AL6P"
-    ],
-    "Professor Layton\nand the Mask of Miracle": [
-        "AKKJ"
-    ],
-    "Professor Layton\nand the Miracle Mask": [
-        "AKKE",
-        "AKKP"
-    ],
-    "Professor Layton\nen de Erfenis van de Azran": [
-        "AL6H"
-    ],
-    "Professor Layton\nen het Masker der Wonderen": [
-        "AKKH"
-    ],
-    "Professor Layton\nund das Verm\u00e4chtnis von Aslant": [
-        "AL6D"
-    ],
-    "Professor Layton\nund die Maske der Wunder": [
-        "AKKD"
-    ],
-    "Project X Zone": [
-        "AXXE",
-        "AXXP"
-    ],
-    "Puppies 3D": [
-        "ACTE"
-    ],
-    "Puppies World 3D": [
-        "ACTP"
-    ],
-    "Purr Pals Purrfection": [
-        "AP6E",
-        "AP6P"
-    ],
-    "Putty Squad": [
-        "AYZE",
-        "AYZP"
-    ],
-    "Puyopuyo Chronicle": [
-        "BPUJ"
-    ],
-    "Puyopuyo Tetris": [
-        "BPTJ"
-    ],
-    "Puzzle & Dragons Z +\nSuper Mario Bros. Edition": [
-        "AZGE",
-        "AZGP"
-    ],
-    "Puzzler Brain Games": [
-        "AAGP"
-    ],
-    "Puzzler Mind Gym 3D": [
-        "APUE",
-        "APUP"
-    ],
-    "Puzzler World 2012 3D": [
-        "APWE",
-        "APWP"
-    ],
-    "Puzzler World 2013": [
-        "AZLE",
-        "AZLP"
-    ],
-    "RABBIDS 3D": [
-        "ARBP"
-    ],
-    "RABBIDS\nTRAVEL IN TIME": [
-        "ARBE"
-    ],
-    "RAYMAN ORIGINS": [
-        "ARME",
-        "ARMJ",
-        "ARMP"
-    ],
-    "RESIDENT EVIL\u00ae\nREVELATIONS": [
-        "ABRE"
-    ],
-    "RESIDENT EVIL\u00ae\nTHE MERCENARIES 3D": [
-        "ABME"
-    ],
-    "RESIDENT EVIL\u2122\nREVELATIONS": [
-        "ABRP"
-    ],
-    "RESIDENT EVIL\u2122\nTHE MERCENARIES 3D": [
-        "ABMP"
-    ],
-    "RIDGE RACER 3D": [
-        "ARRE",
-        "ARRJ",
-        "ARRP"
-    ],
-    "RISE OF THE GUARDIANS": [
-        "ARGE",
-        "ARGP"
-    ],
-    "RPGMaker Fes": [
-        "BRPE",
-        "BRPJ",
-        "BRPP"
-    ],
-    "Rabbids\nRumble": [
-        "AR5E",
-        "AR5P"
-    ],
-    "Rabbids\nTravel In Time": [
-        "ARBJ"
-    ],
-    "Radiant Historia:\nPerfect Chronology": [
-        "BRBE",
-        "BRBP"
-    ],
-    "Rayman 3D": [
-        "ARYE",
-        "ARYP"
-    ],
-    "Rayman and Rabbids\n- Family Pack": [
-        "BRRP"
-    ],
-    "Real Heroes: FireFighter 3D": [
-        "ARHD",
-        "ARHE",
-        "ARHP"
-    ],
-    "Reel Fishing Paradise 3D": [
-        "ARFE",
-        "ARFP"
-    ],
-    "Regular Show\nM&RI8BL": [
-        "AEBE",
-        "AEBP"
-    ],
-    "Return to PopoloCrois:\nA STORY OF SEASONS Fairyt": [
-        "BPPE"
-    ],
-    "Rhythm Paradise Megamix": [
-        "BPJP"
-    ],
-    "Rhythm Thief\n& the Emperor's Treasure": [
-        "ARTE",
-        "ARTJ",
-        "ARTP"
-    ],
-    "Ridge Racer 3D": [
-        "ARRJ"
-    ],
-    "Riding Stables 3D\nJumping for the Team": [
-        "AAPP"
-    ],
-    "Riding Stables 3D\nRivals in the Saddle": [
-        "AMUP"
-    ],
-    "Riding Star 3D": [
-        "ARSP"
-    ],
-    "Rilakkuma\nnakayoshi collection": [
-        "BGYJ"
-    ],
-    "Rilu Rilu Fairilu\nMy First Fairilu Magic\u266a": [
-        "AR8J"
-    ],
-    "River City: RIVAL SHOWDOWN": [
-        "BDJE"
-    ],
-    "River City: Tokyo Rumble": [
-        "AK2E"
-    ],
-    "Rodea the Sky Soldier": [
-        "AR6E",
-        "AR6J",
-        "AR6K",
-        "AR6P"
-    ],
-    "RollerCoaster Tycoon\u00ae 3D": [
-        "AC8E",
-        "AC8P"
-    ],
-    "Rune Factory 4": [
-        "AR4E"
-    ],
-    "RuneFactory4": [
-        "AR4J"
-    ],
-    "SAMURAI WARRIORS:\nChronicles": [
-        "A66E",
-        "A66P"
-    ],
-    "SD GUNDAM\nGGENERATION 3D": [
-        "AGJJ"
-    ],
-    "SEGA 3D Archives": [
-        "BFKJ"
-    ],
-    "SEGA 3D Classics Collection 2": [
-        "BF3J"
-    ],
-    "SEGA 3D Classics Collection": [
-        "AK3E",
-        "AK3J",
-        "AK3P"
-    ],
-    "SENRAN KAGURA 2 SHINKU": [
-        "BNUJ",
-        "BNUK"
-    ],
-    "SENRAN KAGURA 2:\nDeep Crimson": [
-        "BNUE",
-        "BNUP"
-    ],
-    "SENRAN KAGURA Burst": [
-        "AVHJ",
-        "AVHP"
-    ],
-    "SENRAN KAGURA": [
-        "ABHJ"
-    ],
-    "SHIFTING WORLD \u767d\u3068\u9ed2\u306e\u8ff7\u5bae": [
-        "ASZJ"
-    ],
-    "SHOKUGEKI_NO_SOMA": [
-        "BYDJ"
-    ],
-    "SIMPLEseries for Nintendo 3DS\nVol.1 THE MAHJONG": [
-        "AAUJ"
-    ],
-    "SIMPLE\uff7c\uff98\uff70\uff7d\uff9e for \uff86\uff9d\uff83\uff9d\uff84\uff9e\uff703DS\nVol.2 THE\u5bc6\u5ba4\u304b\u3089\u306e\u8131\u51fa \uff71\uff70\uff76\uff72": [
-        "BYEJ"
-    ],
-    "SIMPLE\uff7c\uff98\uff70\uff7d\uff9e for \uff86\uff9d\uff83\uff9d\uff84\uff9e\uff703DS\nVol.3 THE\u5bc6\u5ba4\u304b\u3089\u306e\u8131\u51fa \uff71\uff70\uff76\uff72": [
-        "BP3J"
-    ],
-    "SONIC GENERATIONS": [
-        "ASNE",
-        "ASNJ",
-        "ASNP"
-    ],
-    "SONIC LOST WORLD": [
-        "ARVE",
-        "ARVJ",
-        "ARVP"
-    ],
-    "SPEC\uff5e\u5e72\uff5e": [
-        "BSPJ"
-    ],
-    "STARFOX64 3D": [
-        "ANRJ",
-        "ANRW"
-    ],
-    "STELLA GLOW": [
-        "BS3E",
-        "BS3J",
-        "BS3P"
-    ],
-    "STORY OF SEASONS:\nTrio of Towns": [
-        "BB3E",
-        "BB3P"
-    ],
-    "STORY OF SEASONS": [
-        "BTSE",
-        "BTSP"
-    ],
-    "SUDOKU\n-The Puzzle Game Collection-": [
-        "AS9P"
-    ],
-    "SUPER MARIO 3D LAND": [
-        "AREE",
-        "AREJ",
-        "AREK",
-        "AREP",
-        "AREW",
-        "AREZ"
-    ],
-    "SUPER MONKEY BALL 3D": [
-        "ASME",
-        "ASMJ",
-        "ASMP"
-    ],
-    "SUPER STREET FIGHTER \u2163\n3D EDITION": [
-        "ASSE",
-        "ASSJ",
-        "ASSP"
-    ],
-    "Safari Quest": [
-        "BSQP"
-    ],
-    "Sangokushi 2": [
-        "BSJJ"
-    ],
-    "Sayonara Umihara Kawase": [
-        "AUFJ"
-    ],
-    "Schlag den Raab\nDas 2. Spiel": [
-        "AS2D"
-    ],
-    "Scooby-Doo! & Looney Tunes\nCartoon Universe: Adv": [
-        "BCUE"
-    ],
-    "Scribblenauts Unlimited": [
-        "ASLE",
-        "ASLP",
-        "ASLX"
-    ],
-    "Scribblenauts Unmasked\nA DC Comics Adventure": [
-        "AD6E",
-        "AD6P"
-    ],
-    "Secret Agent Files: Miami": [
-        "ASAP"
-    ],
-    "Secret Mysteries\nIn London": [
-        "ASXP"
-    ],
-    "Secrets of the Titanic\n1912-2012": [
-        "ASEP"
-    ],
-    "Sekaiju to Fushigi no Dungeon2": [
-        "BD5J"
-    ],
-    "Sekaiju to Fushigi no Dungeon": [
-        "BFDJ"
-    ],
-    "Shanghai Mahjong": [
-        "BSMP"
-    ],
-    "Shantae and the Pirate's Curse": [
-        "AJAE",
-        "AJAP",
-        "BP8J"
-    ],
-    "Sherlock Holmes:\nthe Mystery of the Frozen City": [
-        "AHAJ",
-        "AHAP"
-    ],
-    "Shifting World": [
-        "ASZE",
-        "ASZP"
-    ],
-    "Shin Megami Tensei IV:\nApocalypse": [
-        "BG4E",
-        "BG4P"
-    ],
-    "Shin Megami Tensei IV": [
-        "AMXE"
-    ],
-    "Shin Megami Tensei:\nDevil Summoner: Soul Hackers": [
-        "AHQE",
-        "AHQP"
-    ],
-    "Shin Megami Tensei:\nDevil Survivor Overclocked": [
-        "AMTE",
-        "AMTP"
-    ],
-    "Shin Megami Tensei:\nStrange Journey Redux": [
-        "AJ9E",
-        "AJ9P"
-    ],
-    "Shin Megami Tensei\nDEEP STRANGE JOURNEY": [
-        "AJ9J"
-    ],
-    "Shinobi\u2122 3D": [
-        "ASVJ"
-    ],
-    "Shinobi\u2122": [
-        "ASVE",
-        "ASVP"
-    ],
-    "Shovel Knight": [
-        "AKSE",
-        "AKSJ",
-        "AKSP"
-    ],
-    "Skylanders Giants\u2122": [
-        "AG6E",
-        "AG6P",
-        "AG6X"
-    ],
-    "Skylanders SWAP Force\u2122": [
-        "BSFE",
-        "BSFP"
-    ],
-    "Skylanders SuperChargers\u2122": [
-        "BL5P"
-    ],
-    "Skylanders Trap Team\u2122": [
-        "BS9E",
-        "BS9P"
-    ],
-    "Skylanders\u00ae SuperChargers": [
-        "BL5E"
-    ],
-    "Skylanders\nSpyro's Adventure": [
-        "ASPE",
-        "ASPJ",
-        "ASPP"
-    ],
-    "Sonic & All-Stars Racing\nTransformed": [
-        "ALLE",
-        "ALLP"
-    ],
-    "Sonic Boom:\nFire & Ice": [
-        "BS6E",
-        "BS6P"
-    ],
-    "Sonic Boom:\nShattered Crystal": [
-        "BSYE",
-        "BSYP"
-    ],
-    "Sonic Toon:\nFire & Ice": [
-        "BS6J"
-    ],
-    "Sonic Toon:\nIsland Adventure": [
-        "BSYJ"
-    ],
-    "Spider-Man\u2122: Edge of Time": [
-        "AS7E",
-        "AS7P"
-    ],
-    "Spider-Man\u2122:\nAux fronti\u00e8res du temps": [
-        "AS7F"
-    ],
-    "Spirit Camera\nThe Cursed Memoir": [
-        "ALCE",
-        "ALCP"
-    ],
-    "SpongeBob HeroPants": [
-        "BPNE",
-        "BPNP"
-    ],
-    "SpongeBob SquarePants:\nPlankton's Robotic Reveng": [
-        "ANXE",
-        "ANXP"
-    ],
-    "SpongeBob SquigglePants": [
-        "ASGE",
-        "ASGP"
-    ],
-    "Sports Island 3D": [
-        "ADEP"
-    ],
-    "Spot The Differences!": [
-        "BDFP"
-    ],
-    "Spy Hunter\u2122": [
-        "AHEE",
-        "AHEP"
-    ],
-    "Star Fox 64 3D": [
-        "ANRE",
-        "ANRP"
-    ],
-    "Starry\u2606Sky\n\uff5ein Autumn\uff5e 3D": [
-        "AX6J"
-    ],
-    "Starry\u2606Sky\n\uff5ein Spring\uff5e 3D": [
-        "AAXJ"
-    ],
-    "Starry\u2606Sky\n\uff5ein Summer\uff5e 3D": [
-        "AZPJ"
-    ],
-    "Starry\u2606Sky\n\uff5ein Winter\uff5e 3D": [
-        "AX7J"
-    ],
-    "Steel Diver": [
-        "ASDE",
-        "ASDJ",
-        "ASDP"
-    ],
-    "Sternenschweif 3D\nDas Geheimnis im Zauberwald": [
-        "BSCD"
-    ],
-    "Style Savvy: Trendsetters": [
-        "ACLE"
-    ],
-    "Sudoku + 7 other\nComplex Puzzles by Nikoli": [
-        "ANQP"
-    ],
-    "Sudoku by NIKOLI 3D vol.2": [
-        "AZNJ"
-    ],
-    "Sudoku by NIKOLI 3D": [
-        "ANQJ"
-    ],
-    "Suichara\nWelcome to the Sweets School!": [
-        "B2SJ"
-    ],
-    "Super Black Bass 3D": [
-        "ASBE",
-        "ASBP"
-    ],
-    "Super Mario Maker\nfor Nintendo 3DS": [
-        "AJHE",
-        "AJHJ",
-        "AJHP"
-    ],
-    "Super Pok\u00e9mon Rumble": [
-        "ACCJ",
-        "ACCP"
-    ],
-    "Super Smash Bros.\nfor Nintendo 3DS": [
-        "AXCE",
-        "AXCJ",
-        "AXCK",
-        "AXCP"
-    ],
-    "Survivor 3D\nThe Ultimate Adventure": [
-        "AV2P"
-    ],
-    "Survivor\nHeroes": [
-        "BSHP"
-    ],
-    "Sushi Striker\nThe Way of Sushido": [
-        "AFWE",
-        "AFWJ",
-        "AFWP"
-    ],
-    "TALES OF THE ABYSS": [
-        "AABE",
-        "AABJ",
-        "AABP"
-    ],
-    "TEKKEN\u00ae 3D PRIME EDITION": [
-        "ATKE",
-        "ATKJ"
-    ],
-    "TEKKEN\u2122 3D PRIME EDITION": [
-        "ATKK",
-        "ATKP"
-    ],
-    "TENKAI KNIGHTS\u2122\nBRAVE BATTLE": [
-        "BTKE",
-        "BTKP"
-    ],
-    "TERRAFORMARS": [
-        "BFMJ"
-    ],
-    "TETRIS\u00ae": [
-        "ATLJ"
-    ],
-    "THE CROODS": [
-        "AQRE",
-        "AQRP"
-    ],
-    "THEATRHYTHM FINAL FANTASY\nCURTAIN CALL": [
-        "BTHE",
-        "BTHP"
-    ],
-    "THEATRHYTHM\nFINAL FANTASY": [
-        "ATHE",
-        "ATHP"
-    ],
-    "THOMAS & FRIENDS": [
-        "BTBP"
-    ],
-    "TIME TRAVELERS": [
-        "ATRJ"
-    ],
-    "TOEIC\u00ae\u30c6\u30b9\u30c8\n\u8d85\u901f\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
-        "ATEJ"
-    ],
-    "TORIKO GOURMEGABATTLE!": [
-        "BT5J"
-    ],
-    "TRANSFORMERS 3\nStealth Force Edition 3D": [
-        "ATFP"
-    ],
-    "TRANSFORMERS\nPRIME": [
-        "ATPE",
-        "ATPP"
-    ],
-    "TRANSFORMERS\nRise of the Dark Spark": [
-        "AYEE",
-        "AYEP"
-    ],
-    "TURBO": [
-        "AANE",
-        "AANP"
-    ],
-    "TanoshikuOmoshiroku\nKankenshogakusei": [
-        "A3KJ"
-    ],
-    "Teddy Together": [
-        "AKMP"
-    ],
-    "Teenage Mutant Ninja Turtles\u2122:\nDanger of the Ooz": [
-        "BMUE",
-        "BMUP"
-    ],
-    "Teenage Mutant Ninja Turtles\u2122:\nMaster Splinter's": [
-        "BTNE",
-        "BTNP"
-    ],
-    "Teenage Mutant Ninja Turtles\u2122": [
-        "ANYE",
-        "ANYP",
-        "BNTE",
-        "BTWP"
-    ],
-    "Terraria": [
-        "BTEE",
-        "BTEJ",
-        "BTEP"
-    ],
-    "Tetris\u00ae Axis": [
-        "ATLE"
-    ],
-    "Tetris\u00ae Ultimate": [
-        "BTLE",
-        "BTLP"
-    ],
-    "Tetris\u00ae": [
-        "ATLP"
-    ],
-    "The Adventures of Tintin\nThe Secret of the Unico": [
-        "ATNE",
-        "ATNJ",
-        "ATNP"
-    ],
-    "The Alliance Alive": [
-        "AL4E"
-    ],
-    "The Amazing Spider-Man 2\u2122": [
-        "AXYE",
-        "AXYP"
-    ],
-    "The Amazing Spider-Man": [
-        "AS8D",
-        "AS8E",
-        "AS8P"
-    ],
-    "The Cake Shop 2.": [
-        "AWCJ"
-    ],
-    "The Cube": [
-        "ACZP"
-    ],
-    "The Hidden": [
-        "AHDE"
-    ],
-    "The Job's Themepark 2.": [
-        "AWKJ"
-    ],
-    "The LEGO\u00ae Movie\nVideogame": [
-        "AFJD",
-        "AFJE",
-        "AFJF",
-        "AFJJ",
-        "AFJP",
-        "AFJS"
-    ],
-    "The Legend of Korra\u2122:\nA New Era Begins": [
-        "BLDE"
-    ],
-    "The Legend of Legacy": [
-        "BLLE",
-        "BLLP"
-    ],
-    "The Legend of Zelda\nA Link Between Worlds": [
-        "BZLE",
-        "BZLJ",
-        "BZLK",
-        "BZLP"
-    ],
-    "The Legend of Zelda\nMajora's Mask 3D": [
-        "AJRE",
-        "AJRJ",
-        "AJRK",
-        "AJRP"
-    ],
-    "The Legend of Zelda\nOcarina of Time 3D": [
-        "AQEE",
-        "AQEJ",
-        "AQEK",
-        "AQEP",
-        "AQEW"
-    ],
-    "The Legend of Zelda\nTri Force Heroes": [
-        "EA3E",
-        "EA3J",
-        "EA3P",
-        "EA3Z"
-    ],
-    "The Mysterious Cities of Gold:\nSecret Paths": [
-        "BMCP"
-    ],
-    "The Peanuts\u00ae Movie:\nSnoopy's Grand Adventure": [
-        "BPEE",
-        "BPEP"
-    ],
-    "The Penguins of Madagascar": [
-        "BPGE",
-        "BPGP"
-    ],
-    "The SNACK WORLD\nTREJARERS": [
-        "BWSJ"
-    ],
-    "The Sims\u2122 3 Pets": [
-        "AS4E",
-        "AS4J",
-        "AS4P"
-    ],
-    "The Sims\u2122 3": [
-        "AS3E",
-        "AS3J",
-        "AS3P"
-    ],
-    "The Trash Pack": [
-        "ATZE",
-        "ATZP"
-    ],
-    "The Whitakers present\nMilton & Friends 3D": [
-        "AM3P"
-    ],
-    "Thor\u2122:\nGod of Thunder": [
-        "AGTE",
-        "AGTP"
-    ],
-    "Tom Clancy's Ghost Recon\nShadow Wars": [
-        "AGRE",
-        "AGRJ",
-        "AGRP"
-    ],
-    "Tom Clancy's Splinter Cell 3D": [
-        "ASCJ",
-        "ASCP",
-        "ASCZ"
-    ],
-    "Tomodachi Life": [
-        "EC6E",
-        "EC6K",
-        "EC6P"
-    ],
-    "Tongariboshi To Maho no Machi": [
-        "AVCJ"
-    ],
-    "Top Model 3D": [
-        "BT2P"
-    ],
-    "Top Trumps NBA All-Stars": [
-        "AN8E"
-    ],
-    "Toriko! Ultimate Survival.": [
-        "BTCJ"
-    ],
-    "Touch!DoublePenSports": [
-        "APPJ"
-    ],
-    "Transformers\u2122 3\nStealth Force Edition 3D": [
-        "ATFE"
-    ],
-    "Travel Adventures\nwith Hello Kitty": [
-        "AHKE"
-    ],
-    "ULTIMATE NES REMIX": [
-        "BFRP"
-    ],
-    "Ultimate NES Remix": [
-        "BFRE",
-        "BFRJ"
-    ],
-    "Ultra baseball\nAction card battle": [
-        "BUBJ"
-    ],
-    "Viking Invasion 2\nTower Defense": [
-        "AVKP"
-    ],
-    "Virtue's Last Reward": [
-        "AKGP"
-    ],
-    "VitaminX\nEvolution Plus": [
-        "BVXJ"
-    ],
-    "VitaminZ\nRevolution": [
-        "BVZJ"
-    ],
-    "WORLD SOCCER\nWinning Eleven 2012": [
-        "AE2J"
-    ],
-    "WORLD SOCCER\nWinning Eleven 2013": [
-        "AWTJ"
-    ],
-    "WORLD SOCCER\nWinning Eleven 2014 JE": [
-        "BSBJ"
-    ],
-    "WORLD SOCCER\nWinning Eleven 2014": [
-        "BW4J"
-    ],
-    "WRC The Official Game": [
-        "BWRP"
-    ],
-    "WWE All Stars": [
-        "AWEE",
-        "AWEP"
-    ],
-    "WarioWare Gold": [
-        "AWXA"
-    ],
-    "Winning Eleven 3DSoccer": [
-        "AEEJ"
-    ],
-    "Winter Sports 2012\nFeel the Spirit": [
-        "AWSP"
-    ],
-    "Winx Club: Saving Alfea": [
-        "BWCE",
-        "BWCP"
-    ],
-    "Wipeout 2": [
-        "AWPE"
-    ],
-    "Wipeout 3": [
-        "AW3E"
-    ],
-    "Wipeout Create & Crash": [
-        "AY8E"
-    ],
-    "Word Wizard 3D": [
-        "AWWP"
-    ],
-    "YO-KAI SANGOKUSHI": [
-        "AYKJ"
-    ],
-    "YO-KAI WATCH 2:\nBONY SPIRITS": [
-        "BYGP"
-    ],
-    "YO-KAI WATCH 2:\nFLESHY SOULS": [
-        "BYHP"
-    ],
-    "YO-KAI WATCH 2:\nPSYCHIC SPECTERS": [
-        "BYSE",
-        "BYSP",
-        "BYSZ"
-    ],
-    "YO-KAI WATCH BLASTERS\nRED CAT CORPS": [
-        "BYAE",
-        "BYAP"
-    ],
-    "YO-KAI WATCH BLASTERS\nWHITE DOG SQUAD": [
-        "BYBE",
-        "BYBP"
-    ],
-    "YO-KAI WATCH BUSTERS 2\nMAGNUM": [
-        "BYMJ"
-    ],
-    "YO-KAI WATCH BUSTERS 2\nSWORD": [
-        "BYNJ"
-    ],
-    "YO-KAI WATCH": [
-        "AYWE",
-        "AYWK",
-        "AYWP",
-        "AYWZ"
-    ],
-    "YOSHI'S New ISLAND": [
-        "ATAE",
-        "ATAJ",
-        "ATAP",
-        "ATAZ"
-    ],
-    "Yakari": [
-        "AYRP"
-    ],
-    "Yo-kai Watch 2 Bony Spirits": [
-        "BYGE",
-        "BYGZ"
-    ],
-    "Yo-kai Watch 2 Fleshy Souls": [
-        "BYHE",
-        "BYHZ"
-    ],
-    "Yo-kai Watch 3": [
-        "ALZD",
-        "ALZE",
-        "ALZF",
-        "ALZI",
-        "ALZP",
-        "ALZS"
-    ],
-    "Yokai Watch 2 ganso": [
-        "BYGJ"
-    ],
-    "Yokai Watch 2 honke": [
-        "BYHJ"
-    ],
-    "Yokai Watch 2 shinuchi": [
-        "BYSJ"
-    ],
-    "Yokai Watch 3 SUKIYAKI": [
-        "ALZJ"
-    ],
-    "Yokai Watch 3 SUSHI": [
-        "BY3J"
-    ],
-    "Yokai Watch 3 TEMPURA": [
-        "BY4J"
-    ],
-    "Yokai Watch Busters\nAkaneko Dan": [
-        "BYAJ"
-    ],
-    "Yokai Watch Busters\nShiroinu Tai": [
-        "BYBJ"
-    ],
-    "Yokai Watch": [
-        "AYWJ"
-    ],
-    "Young Justice\u2122: Legacy": [
-        "AYJE"
-    ],
-    "Yu-Gi-Oh! ZEXAL\nWorld Duel Carnival": [
-        "AYXP"
-    ],
-    "Yu-Gi-Oh!ZEXAL": [
-        "AYXJ"
-    ],
-    "ZERO ESCAPE": [
-        "BZGJ"
-    ],
-    "ZETSUBO YOSAI\nescape adventure": [
-        "AZUJ"
-    ],
-    "ZOO MANIA\nBUILD YOUR DREAM ZOO": [
-        "ANMJ"
-    ],
-    "ZOO RESORT": [
-        "AZOE",
-        "AZOP"
-    ],
-    "Zero Escape:\nVirtue's Last Reward": [
-        "AKGE"
-    ],
-    "Zero Escape:\nZero Time Dilemma": [
-        "BZEE"
-    ],
-    "aikatsu!my two princesses": [
-        "BAKJ"
-    ],
-    "atelier deco la doll\ncollection": [
-        "AULJ"
-    ],
-    "attack on titan 2\nfuture": [
-        "AKPJ"
-    ],
-    "attack on titan\nchain": [
-        "BG2J"
-    ],
-    "attack on titan": [
-        "BGAJ"
-    ],
-    "beybladeburstgod": [
-        "BVBJ"
-    ],
-    "beybladeburst": [
-        "BUTJ"
-    ],
-    "cooking mama 4:Kitchen Magic": [
-        "ACQE"
-    ],
-    "cooking mama 4": [
-        "ACQP"
-    ],
-    "doodle jump adventures": [
-        "AEGE",
-        "AEGP",
-        "AEGZ"
-    ],
-    "hoppechan minnadeodekake!\nwakuwaku hoppeland!!": [
-        "BH2J"
-    ],
-    "hoppechan tukutte!\nasonde! punipunitown!!": [
-        "BHPJ"
-    ],
-    "hoppechan\npunittoshibotte daibouken!": [
-        "BH3J"
-    ],
-    "kekiyasan monogatari\noishiisuituwotukurou": [
-        "BC8J"
-    ],
-    "kinkinomaguna": [
-        "BKKJ"
-    ],
-    "kouenji joshi soccer 3\nkoisuruirebun itukaha hea": [
-        "BKJJ"
-    ],
-    "kuniokun special": [
-        "AK9J"
-    ],
-    "minna no ennichi": [
-        "AENJ"
-    ],
-    "nicopuchi": [
-        "BNPJ"
-    ],
-    "nintendogs + cats": [
-        "ADAE",
-        "ADAJ",
-        "ADAP",
-        "ADAW",
-        "ADBE",
-        "ADBJ",
-        "ADBP",
-        "ADBW",
-        "ADCE",
-        "ADCJ",
-        "ADCP",
-        "ADCW"
-    ],
-    "pikapika nurse story2": [
-        "ANAJ"
-    ],
-    "pikapikanasumonogatari\nsyounikahaitumooosawagi": [
-        "AG4J"
-    ],
-    "sumikkogurasi\nkoko,dokonandesu?": [
-        "AWHJ"
-    ],
-    "sumikkogurasi\nkokogaochitukunndesu": [
-        "BCNJ"
-    ],
-    "sumikkogurasi\nmurawotukurunndesu": [
-        "BVSJ"
-    ],
-    "sumikkogurasi\nomisehazimerundesu": [
-        "BSVJ"
-    ],
-    "the Smurfs\u2122": [
-        "BUSE",
-        "BUSP"
-    ],
-    "wan-nyan hospital2": [
-        "AWNJ"
-    ],
-    "wannyan petshop": [
-        "BWNJ"
-    ],
-    "wannyandoubutsubyouin\npettonooisyasanninarou": [
-        "BW2J"
-    ],
-    "wannyandoubutsubyouin\nsutekinajyuuisanninarou": [
-        "AWJJ"
-    ],
-    "\u719f\u8a9e \u901f\u5f15\u8f9e\u5178": [
-        "AJXJ"
-    ],
-    "\u30de\u30ae\n\u65b0\u305f\u306a\u308b\u4e16\u754c": [
-        "BNWJ"
-    ],
-    "\u30de\u30ae\n\u306f\u3058\u307e\u308a\u306e\u8ff7\u5bae": [
-        "ALMJ"
-    ],
-    "\u30b4\u30f3\n\u30d0\u30af\u30d0\u30af\u30d0\u30af\u30d0\u30af\u30a2\u30c9\u30d9\u30f3\u30c1\u30e3\u30fc": [
-        "AG7J"
-    ],
-    "\u96f7\u5b50": [
-        "BRSJ"
-    ],
-    "\u8584\u685c\u9b3c 3D": [
-        "AH9J"
-    ],
-    "\u30c8\u30ea\u30b3 \u30b0\u30eb\u30e1\u30e2\u30f3\u30b9\u30bf\u30fc\u30ba\uff01": [
-        "AT6J"
-    ],
-    "\u85e4\u5b50\u30fbF\u30fb\u4e0d\u4e8c\u96c4\u30ad\u30e3\u30e9\u30af\u30bf\u30fc\u30ba\n\u5927\u96c6\u5408\uff01SF\u30c9\u30bf\u30d0\u30bf\u30d1\u30fc\u30c6\u30a3\u30fc\uff01\uff01": [
-        "BFPJ"
-    ],
-    "\u8b0e\u60d1\u9928\n\u97f3\u306e\u9593\u306b\u9593\u306b": [
-        "ANWJ"
-    ],
-    "\u4e09\u570b\u5fd7": [
-        "BGKJ"
-    ],
-    "\u6226\u56fd\u7121\u53cc Chronicle \uff13": [
-        "BC4J"
-    ],
-    "\u9b54\u754c\u738b\u5b50 devils and realist\n\u4ee3\u7406\u738b\u306e\u79d8\u5b9d": [
-        "BDPJ"
-    ],
-    "\u30c6\u30a4\u30eb\u30ba \u30aa\u30d6 \u30b6 \u30ef\u30fc\u30eb\u30c9\n\u30ec\u30fc\u30f4 \u30e6\u30ca\u30a4\u30c6\u30a3\u30a2": [
-        "ATUJ"
-    ],
-    "\u30d7\u30ed\u91ce\u7403 \u30d5\u30a1\u30df\u30b9\u30bf \u30ea\u30bf\u30fc\u30f3\u30ba": [
-        "BP5J"
-    ],
-    "\u30d7\u30ed\u91ce\u7403 \u30d5\u30a1\u30df\u30b9\u30bf \u30af\u30e9\u30a4\u30de\u30c3\u30af\u30b9": [
-        "BYFJ"
-    ],
-    "\u6697\u6bba\u6559\u5ba4 \u30a2\u30b5\u30b7\u30f3\u80b2\u6210\u8a08\u753b!!": [
-        "BA2J"
-    ],
-    "\u30ad\u30e9\u30e1\u30ad \u308f\u304f\u308f\u304f\u30b9\u30a4\u30fc\u30c4": [
-        "BSWJ"
-    ],
-    "\u6697\u6bba\u6559\u5ba4 \u6bba\u305b\u3093\u305b\u30fc\u5927\u5305\u56f2\u7db2!!": [
-        "BKLJ"
-    ],
-    "\u9006\u8ee2\u88c1\u5224123\u3000\u6210\u6b69\u5802\u30bb\u30ec\u30af\u30b7\u30e7\u30f3": [
-        "BHDJ"
-    ],
-    "\u6975\u9650\u8131\u51faADV\n\u5584\u4eba\u30b7\u30dc\u30a6\u30c7\u30b9": [
-        "AKGJ"
-    ],
-    "\u30cf\u30de\u30c8\u30e9\nLook at Smoking World": [
-        "BATJ"
-    ],
-    "\u307e\u3081\u30b4\u30de\n\u3088\u3044\u3053 \u307e\u308b\u3044\u3053 \u3052\u3093\u304d\u306a\u3053\uff01": [
-        "AM6J"
-    ],
-    "\u30d7\u30ea\u30d1\u30e9\n\u3081\u3056\u3081\u3088!\u5973\u795e\u306e\uff84\uff9e\uff9a\uff7d\uff83\uff9e\uff7b\uff9e\uff72\uff9d": [
-        "BP7J"
-    ],
-    "\u7267\u5834\u7269\u8a9e\n\u3075\u305f\u3054\u306e\u6751\uff0b": [
-        "A22J"
-    ],
-    "\u7267\u5834\u7269\u8a9e\n\u306f\u3058\u307e\u308a\u306e\u5927\u5730": [
-        "ABQJ"
-    ],
-    "\u7267\u5834\u7269\u8a9e\n\u3064\u306a\u304c\u308b\u65b0\u5929\u5730": [
-        "BTSJ"
-    ],
-    "\u30c9\u30e9\u304b\u305a\n\u306e\u3073\u592a\u306e\u3059\u3046\u3058\u5927\u5192\u967a": [
-        "ADWJ"
-    ],
-    "\u7267\u5834\u7269\u8a9e\n\uff13\u3064\u306e\u91cc\u306e\u5927\u5207\u306a\u53cb\u3060\u3061": [
-        "BB3J"
-    ],
-    "\u307e\u3081\u30b4\u30de\n\u306f\u3063\u3074\u30fc\uff01\u30b9\u30a4\u30fc\u30c4\u30d5\u30a1\u30fc\u30e0": [
-        "AGWJ"
-    ],
-    "\u307e\u307b\u30b3\u30ec\n\u9b54\u6cd5\u2606\u3042\u3044\u3069\u308b\u30b3\u30ec\u30af\u30b7\u30e7\u30f3": [
-        "BM8J"
-    ],
-    "\u30d7\u30ea\u30d1\u30e9\n\u3081\u3056\u305b\uff01\uff71\uff72\uff84\uff9e\uff99\u2606\uff78\uff9e\uff97\uff9d\uff8c\uff9f\uff98No.1\uff01": [
-        "APJJ"
-    ],
-    "\u307e\u3081\u3057\u3070": [
-        "AMEJ"
-    ],
-    "\u30bd\u30cb\u30d7\u30ed": [
-        "BS2J"
-    ],
-    "\u95d8\u795e\u90fd\u5e02": [
-        "BTTJ"
-    ],
-    "\u30c7\u30a3\u30ba\u30cb\u30fc\u00a0\u30a8\u30d4\u30c3\u30af\u30df\u30c3\u30ad\u30fc\uff1a\n\u30df\u30c3\u30ad\u30fc\u306e\u3075\u3057\u304e\u306a\u5192\u967a": [
-        "AECJ"
-    ],
-    "\u5927\u9006\u8ee2\u88c1\u5224 -\u6210\u6b69\u5802\u9f8d\u30ce\u4ecb\u306e\u5192\u96aa-": [
-        "BDGJ"
-    ],
-    "\u30ef\u30f3\u30d4\u30fc\u30b9 ROMANCE DAWN\n\u5192\u967a\u306e\u591c\u660e\u3051": [
-        "BRDJ"
-    ],
-    "\u592a\u9f13\u306e\u9054\u4eba \u30c9\u30b3\u30c9\u30f3\uff01\n\u30df\u30b9\u30c6\u30ea\u30fc\u30a2\u30c9\u30d9\u30f3\u30c1\u30e3\u30fc": [
-        "BT8J"
-    ],
-    "\u8d85\u30fb\u6226\u95d8\u4e2d \u7a76\u6975\u306e\u5fcd\u3068\n\u30d0\u30c8\u30eb\u30d7\u30ec\u30a4\u30e4\u30fc\u9802\u4e0a\u6c7a\u6226\uff01": [
-        "AJSJ"
-    ],
-    "\u30e1\u30c0\u30ed\u30c3\u30c8 \u30af\u30e9\u30b7\u30c3\u30af\u30b9\n\u30ab\u30d6\u30c8Ver.": [
-        "BKUJ"
-    ],
-    "\u30e1\u30c0\u30ed\u30c3\u30c8 \u30af\u30e9\u30b7\u30c3\u30af\u30b9\n\u30af\u30ef\u30ac\u30bfVer.": [
-        "BKWJ"
-    ],
-    "\u30ea\u30ba\u30e0\u5929\u56fd \u30b6\u30fb\u30d9\u30b9\u30c8\uff0b": [
-        "BPJJ"
-    ],
-    "\u5f31\u866b\u30da\u30c0\u30eb \u660e\u65e5\u3078\u306e\u9ad8\u56de\u8ee2": [
-        "AYPJ"
-    ],
-    "\u30c9\u30e9\u3048\u3082\u3093 \u306e\u3073\u592a\u3068\u5947\u8de1\u306e\u5cf6\n\uff5e\u30a2\u30cb\u30de\u30eb \u30a2\u30c9\u30d9\u30f3\u30c1\u30e3\u30fc\uff5e": [
-        "AA2J"
-    ],
-    "\u30ad\u30e9\u2605\u30e1\u30ad \u304a\u3057\u3083\u308c\u30b5\u30ed\u30f3\uff01\n\uff5e\u308f\u305f\u3057\u306e\u3057\u3054\u3068\u306f\u7f8e\u5bb9\u5e2b\u3055\u3093\uff5e": [
-        "AATJ"
-    ],
-    "\u5fc3\u970a\u30ab\u30e1\u30e9 \uff5e\u6191\u3044\u3066\u308b\u624b\u5e33\uff5e": [
-        "ALCJ"
-    ],
-    "\u30c9\u30e9\u3048\u3082\u3093 \u65b0\u30fb\u306e\u3073\u592a\u306e\u5927\u9b54\u5883\n\uff5e\u30da\u30b3\u3068\uff15\u4eba\u306e\u63a2\u691c\u968a\uff5e": [
-        "BNMJ"
-    ],
-    "\u30c9\u30e9\u3048\u3082\u3093 \u65b0\u30fb\u306e\u3073\u592a\u306e\u65e5\u672c\u8a95\u751f": [
-        "BNNJ"
-    ],
-    "\u30cf\u30a4\u30ad\u30e5\u30fc!! Cross team match\uff01": [
-        "BHTJ"
-    ],
-    "\u30cf\u30a4\u30ad\u30e5\u30fc!! \u7e4b\u3052!\u9802\u306e\u666f\u8272!!": [
-        "BHQJ"
-    ],
-    "\u6d1e\u7a9f\u7269\u8a9e\uff13D": [
-        "ACVJ"
-    ],
-    "\u30a2\u30a4\u30ab\u30c4\uff01\n365\u65e5\u306e\u30a2\u30a4\u30c9\u30eb\u30c7\u30a4\u30ba": [
-        "BA3J"
-    ],
-    "\u30a2\u30a4\u30ab\u30c4\uff01\nMy No.1 Stage!": [
-        "AK4J"
-    ],
-    "\u4e03\u3064\u306e\u5927\u7f6a\n\u771f\u5b9f\u306e\u51a4\u7f6a": [
-        "BS7J"
-    ],
-    "\u30c9\u30e9\u3048\u3082\u3093\n\u306e\u3073\u592a\u306e\u5b9d\u5cf6": [
-        "BNLJ"
-    ],
-    "\u30d1\u30ba\u30c9\u30e9\uff3a\n\u9650\u5b9a\u30c1\u30e3\u30ec\u30f3\u30b8\u7248": [
-        "APZJ"
-    ],
-    "\u30ef\u30f3\u30d4\u30fc\u30b9\n\u8d85\u30b0\u30e9\u30f3\u30c9\u30d0\u30c8\u30eb\uff01\uff38": [
-        "BG3J"
-    ],
-    "\u592a\u9f13\u306e\u9054\u4eba\n\u3069\u3093\u3068\u304b\u3064\u306e\u6642\u7a7a\u5927\u5192\u967a": [
-        "BT7J"
-    ],
-    "\u30c9\u30e9\u3048\u3082\u3093\n\u306e\u3073\u592a\u306e\u3072\u307f\u3064\u9053\u5177\u535a\u7269\u9928": [
-        "AD9J"
-    ],
-    "\u30ef\u30f3\u30d4\u30fc\u30b9\n\u30a2\u30f3\u30ea\u30df\u30c6\u30c3\u30c9\u30af\u30eb\u30fc\u30ba\uff33\uff30": [
-        "ALFJ"
-    ],
-    "\u30d1\u30ba\u30c9\u30e9\uff3a\n\u30b3\u30ed\u30b3\u30ed\u30b3\u30df\u30c3\u30af\u9650\u5b9a\u4f53\u9a13\u7248": [
-        "ANFJ"
-    ],
-    "\u30c9\u30e9\u3048\u3082\u3093\n\u306e\u3073\u592a\u306e\u5357\u6975\u30ab\u30c1\u30b3\u30c1\u5927\u5192\u967a": [
-        "BDUJ"
-    ],
-    "\u8d85\u30fb\u9003\u8d70\u4e2d\n\u3042\u3064\u307e\u308c\uff01\u6700\u5f37\u306e\u9003\u8d70\u8005\u305f\u3061": [
-        "BTUJ"
-    ],
-    "\u592a\u9f13\u306e\u9054\u4eba\n\u3061\u3073\u30c9\u30e9\u30b4\u30f3\u3068\u4e0d\u601d\u8b70\u306a\u30aa\u30fc\u30d6": [
-        "ATDJ"
-    ],
-    "\u3054\u5f53\u5730\u9244\u9053\n\uff5e\u3054\u5f53\u5730\u30ad\u30e3\u30e9\u3068\u65e5\u672c\u5168\u56fd\u306e\u65c5\uff5e": [
-        "BLTJ"
-    ],
-    "\u30cd\u30b3\u30fb\u30c8\u30e2\n\u307b\u3093\u308f\u304b\u5bb6\u65cf\u304c\u3067\u304d\u3061\u3083\u3046\u30b2\u30fc\u30e0": [
-        "BNFJ"
-    ],
-    "\u9006\u8ee2\u88c1\u5224\uff15": [
-        "AGKJ"
-    ],
-    "\u30af\u30de\u30fb\u30c8\u30e2": [
-        "AKMJ"
-    ],
-    "\u30d1\u30ba\u30c9\u30e9\uff3a": [
-        "AZGJ"
-    ],
-    "\u30b7\u30a2\u30c8\u30ea\u30ba\u30e0 FF \u30ab\u30fc\u30c6\u30f3\u30b3\u30fc\u30eb": [
-        "BTHJ"
-    ],
-    "\u304a\u3055\u308f\u308a\u63a2\u5075 \u5c0f\u6ca2\u91cc\u5948 \u30e9\u30a4\u30b8\u30f3\u30b0\uff13\n\u306a\u3081\u3053\u306f\u30d0\u30ca\u30ca\u306e\u5922\u3092\u898b\u308b\u304b\uff1f": [
-        "AN7J"
-    ],
-    "\u30cf\u30b3\u30dc\u30fc\u30a4\uff01 \u30cf\u30b3\u3065\u3081\uff22\uff2f\uff38": [
-        "BC2J"
-    ],
-    "\u4eee\u9762\u30e9\u30a4\u30c0\u30fc \u30c8\u30e9\u30d9\u30e9\u30fc\u30ba\u6226\u8a18": [
-        "AXAJ"
-    ],
-    "\u30b7\u30a2\u30c8\u30ea\u30ba\u30e0 \u30c9\u30e9\u30b4\u30f3\u30af\u30a8\u30b9\u30c8": [
-        "BTQJ"
-    ],
-    "\uff2e\uff21\uff32\uff35\uff34\uff2f \uff33\uff24\u30d1\u30ef\u30d5\u30eb\u75be\u98a8\u4f1d": [
-        "AN4J",
-        "AN4Z"
-    ],
-    "\uff8c\uff9f\uff98\uff8a\uff9f\uff97&\uff8c\uff9f\uff98\uff83\uff68\uff70\uff98\uff7d\uff9e\uff91 \uff8c\uff9f\uff98\uff8a\uff9f\uff97\u3067\n\u3064\u304b\u3048\u308b\u304a\u3057\u3083\u308c\uff71\uff72\uff83\uff911450!": [
-        "BPAJ"
-    ],
-    "\u304b\u308f\u3044\u3044\u4ed4\u72ac3D": [
-        "ACTJ"
-    ],
-    "\u3053\u3073\u3068\u3065\u304b\u3093\n\u3053\u3073\u3068\u306e\u4e0d\u601d\u8b70 \u5b9f\u9a13\u30bb\u30c3\u30c8": [
-        "BK2J"
-    ],
-    "\u9ed2\u5b50\u306e\u30d0\u30b9\u30b1\n\u672a\u6765\u3078\u306e\u30ad\u30ba\u30ca": [
-        "AK5J"
-    ],
-    "\u9ed2\u5b50\u306e\u30d0\u30b9\u30b1\n\u52dd\u5229\u3078\u306e\u30ad\u30bb\u30ad": [
-        "BASJ"
-    ],
-    "\u3053\u3073\u3068\u3065\u304b\u3093\n\u3053\u3073\u3068\u89b3\u5bdf\u30bb\u30c3\u30c8": [
-        "AKVJ"
-    ],
-    "\u30d9\u30a4\u30de\u30c3\u30af\u30b9\n\u30d2\u30fc\u30ed\u30fc\u30ba\u30d0\u30c8\u30eb": [
-        "BH6J"
-    ],
-    "\u30e2\u30f3\u30cf\u30f3\u65e5\u8a18\n\u307d\u304b\u307d\u304b\u30a2\u30a4\u30eb\u30fc\u6751DX": [
-        "BARJ"
-    ],
-    "\u5927\u9006\u8ee2\u88c1\u5224\uff12\n\u2015\u6210\u6b69\u5802\u9f8d\u30ce\u4ecb\u306e\u89ba\u609f\u2015": [
-        "AJ2J"
-    ],
-    "\u30b7\u30a2\u30c8\u30ea\u30ba\u30e0\n\u30d5\u30a1\u30a4\u30ca\u30eb\u30d5\u30a1\u30f3\u30bf\u30b8\u30fc": [
-        "ATHJ"
-    ],
-    "\u305f\u307e\u3054\u3063\u3061\u306e\n\u30c9\u30ad\u30c9\u30ad\u2606\u30c9\u30ea\u30fc\u30e0\u304a\u307f\u305b\u3063\u3061": [
-        "AT8J"
-    ],
-    "\u305f\u307e\u3054\u3063\u3061\uff01\n\u305b\u30fc\u3057\u3085\u3093\u306e\u30c9\u30ea\u30fc\u30e0\u30b9\u30af\u30fc\u30eb": [
-        "BD6J"
-    ],
-    "\u3061\u3073\u2606\u30c7\u30d3\uff01": [
-        "AD8J"
-    ],
-    "\u3077\u3088\u3077\u3088\uff01\uff01": [
-        "AP2J"
-    ],
-    "\u30a2\u30a4\u30c9\u30eb\u30bf\u30a4\u30e0 \u30d7\u30ea\u30d1\u30e9\n\u5922\u30aa\u30fc\u30eb\u30b9\u30bf\u30fc\u30e9\u30a4\u30d6\uff01": [
-        "B2PJ"
-    ],
-    "\u30c0\u30f3\u30dc\u30fc\u30eb\u6226\u6a5f \u7206\u30d6\u30fc\u30b9\u30c8": [
-        "ADNJ"
-    ],
-    "\u63a2\u5075\u795e\u5bae\u5bfa\u4e09\u90ce \u5fa9\u8b90\u306e\u8f2a\u821e": [
-        "AJGJ"
-    ],
-    "\u304a\u3046\u3061\u307e\u3044\u306b\u3061 \u305f\u307e\u3054\u3063\u3061": [
-        "AQCJ"
-    ],
-    "\u30ab\u30bf\u30c1\u65b0\u767a\u898b\uff01 \u7acb\u4f53\u30d4\u30af\u30ed\u30b9\uff12": [
-        "BBPJ"
-    ],
-    "\u77ac\u8db3\u3000\u3081\u3056\u305b\uff01 \u5168\u56fd\u6700\u5f37\u30e9\u30f3\u30ca\u30fc": [
-        "BSNJ"
-    ],
-    "\u30cf\u30a4\u30b9\u30af\u30fc\u30eb\uff24\u00d7\uff24": [
-        "BDDJ"
-    ],
-    "\u30ba\u30fc\u30ad\u30fc\u30d1\u30fc\uff13D": [
-        "AZKJ"
-    ],
-    "\u30c0\u30f3\u30dc\u30fc\u30eb\u6226\u6a5fW \u8d85\u30ab\u30b9\u30bf\u30e0": [
-        "BDWJ"
-    ],
-    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30ebZ\n\u8d85\u7a76\u6975\u6b66\u95d8\u4f1d": [
-        "BDVJ"
-    ],
-    "\u63a2\u5075\u795e\u5bae\u5bfa\u4e09\u90ce\nGHOST OF THE DUSK": [
-        "BG9J"
-    ],
-    "\u4e16\u754c\u6a39\u306e\u8ff7\u5bae\u2163\n\u4f1d\u627f\u306e\u5de8\u795e": [
-        "ASJJ"
-    ],
-    "\u30da\u30f3\u30ae\u30f3\u306e\u554f\u984c\n\u30b6\u30fb\u30a6\u30a9\u30fc\u30ba": [
-        "AP5J"
-    ],
-    "\u30ec\u30a4\u30c8\u30f3\u6559\u6388\u3068\n\u8d85\u6587\u660e\uff21\u306e\u907a\u7523": [
-        "AL6J"
-    ],
-    "\u96e3\u653b\u4e0d\u843d\u4e09\u56fd\u4f1d\n\uff5e\u8700\u3068\u6642\u306e\u9285\u96c0\uff5e": [
-        "BSDJ"
-    ],
-    "\u6589\u6728\u6960\u96c4\u306e\u03a8\u96e3\n\u53f2\u4e0a\u03a8\u5927\u306e\u03a8\u96e3\uff01\uff1f": [
-        "AKAJ"
-    ],
-    "\u30e9\u30f3\u30b0\u30ea\u30c3\u30b5\u30fc\n\u30ea\u30a4\u30f3\u30ab\u30fc\u30cd\u30fc\u30b7\u30e7\u30f3 -\u8ee2\u751f-": [
-        "BRGJ"
-    ],
-    "\u3061\u3073\u2606\u30c7\u30d3\uff01\uff12\n\uff5e\u9b54\u6cd5\u306e\u3086\u3081\u3048\u307b\u3093\uff5e": [
-        "ADSJ"
-    ],
-    "\u30af\u30c3\u30ad\u30f3\u30b0\u30de\u30de\n\u308f\u305f\u3057\u306e\u30b9\u30a4\u30fc\u30c4\u30b7\u30e7\u30c3\u30d7": [
-        "BS8J"
-    ],
-    "\u602a\u76d7\u30b8\u30e7\u30fc\u30ab\u30fc\n\u6642\u3092\u8d85\u3048\u308b\u602a\u76d7\u3068\u5931\u308f\u308c\u305f\u5b9d\u77f3": [
-        "AKJJ"
-    ],
-    "\u3061\u3087\uff5e\u308a\u3063\u3061\uff01\n\u305f\u307e\u3054\u3063\u3061\u306e\u30d7\u30c1\u30d7\u30c1\u304a\u307f\u305b\u3063\u3061": [
-        "AT5J"
-    ],
-    "\u30de\u30ea\u30aa\u30ab\u30fc\u30c8\uff17": [
-        "AMKJ"
-    ],
-    "\u771f\u30fb\u5973\u795e\u8ee2\u751f\u2163": [
-        "AMXJ",
-        "AMXZ"
-    ],
-    "\u30d2\u30fc\u30ed\u30fc\u30d0\u30f3\u30af": [
-        "BHBJ"
-    ],
-    "\u30c8\u30e9\u30a4\u30d6\u30af\u30eb\u30af\u30eb THE G@ME": [
-        "BQRJ"
-    ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u7fbd\u7530 ALL STARS": [
-        "BKAJ"
-    ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u6210\u7530 ALL STARS": [
-        "BNAJ"
-    ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u95a2\u7a7a ALL STARS": [
-        "BPKJ"
-    ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u90a3\u8987 PREMIUM": [
-        "AX5J"
-    ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u95a2\u7a7a SKY STORY": [
-        "AKXJ"
-    ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u7fbd\u7530 with \uff2a\uff21\uff2c": [
-        "AH7J"
-    ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u6210\u7530 with \uff21\uff2e\uff21": [
-        "AN6J"
-    ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u65b0\u5343\u6b73 with \uff2a\uff21\uff2c": [
-        "BBKJ"
-    ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u30db\u30ce\u30eb\u30eb": [
-        "AHWJ"
-    ],
-    "\u30aa\u30ec\u69d8\u30ad\u30f3\u30b0\u30c0\u30e0 \uff72\uff79\uff92\uff9d\u5f7c\u6c0f\u3092\n\uff79\uff9e\uff6f\uff84\u3057\u3088\uff01\u3082\u3048\uff77\uff6d\uff9d\u2665\uff7d\uff78\uff70\uff99\uff83\uff9e\uff72\uff7d\uff9e": [
-        "AK7J"
-    ],
-    "\u30c7\u30d3\u30eb\u30b5\u30d0\u30a4\u30d0\u30fc \u30aa\u30fc\u30d0\u30fc\u30af\u30ed\u30c3\u30af": [
-        "ADVJ"
-    ],
-    "\u30c7\u30d3\u30eb\u30b5\u30d0\u30a4\u30d0\u30fc2\n\u30d6\u30ec\u30a4\u30af\u30ec\u30b3\u30fc\u30c9": [
-        "ADXJ"
-    ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO2\n\u30af\u30ed\u30ce\u30fb\u30b9\u30c8\u30fc\u30f3 \"\u30cd\u30c3\u30d7\u30a6\"": [
-        "ANPJ"
-    ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO2\n\u30af\u30ed\u30ce\u30fb\u30b9\u30c8\u30fc\u30f3 \"\u30e9\u30a4\u30e1\u30a4\"": [
-        "ARAJ"
-    ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\n\u30c0\u30fc\u30af": [
-        "AEDJ"
-    ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\n\u30b7\u30e3\u30a4\u30f3": [
-        "AE4J"
-    ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\n\u30ae\u30e3\u30e9\u30af\u30b7\u30fc \u30d3\u30c3\u30b0\u30d0\u30f3": [
-        "BGVJ"
-    ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\n\u30ae\u30e3\u30e9\u30af\u30b7\u30fc \u30b9\u30fc\u30d1\u30fc\u30ce\u30f4\u30a1": [
-        "BGSJ"
-    ],
-    "\u30c7\u30b8\u30e2\u30f3\u30ef\u30fc\u30eb\u30c9\nRe:Digitize Decode": [
-        "ADJJ"
-    ],
-    "\u30de\u30ea\u30aa\uff06\u30bd\u30cb\u30c3\u30af\n\uff21\uff34 \u30ed\u30f3\u30c9\u30f3\u30aa\u30ea\u30f3\u30d4\u30c3\u30af": [
-        "ACMJ"
-    ],
-    "\u30a2\u30af\u30ea\u30eb\u30d1\u30ec\u30c3\u30c8\n\uff5e\u5f69\u308a\u30ab\u30d5\u30a7\u30fbCheers\uff5e": [
-        "AYDJ"
-    ],
-    "\u30e9\u30f3\u30ca\u30d0\u30a6\u30c8\uff13\uff24\n\u30c9\u30e9\u30a4\u30d6\uff1a\u30a4\u30f3\u30dd\u30c3\u30b7\u30d6\u30eb": [
-        "ARNJ"
-    ],
-    "\u68a8\u6c41\u30a2\u30af\u30b7\u30e7\u30f3\uff01\n\u3075\u306a\u3063\u3057\u30fc\u306e\u6109\u5feb\u306a\u304a\u306f\u306a\u3063\u3057\u30fc": [
-        "BFCJ"
-    ],
-    "\u65b0\u30c6\u30cb\u30b9\u306e\u738b\u5b50\u69d8\n\uff5e\uff27\uff4f\u3000\uff54\uff4f\u3000\uff54\uff48\uff45\u3000\uff54\uff4f\uff50\uff5e": [
-        "BTPJ"
-    ],
-    "\uff4e\uff49\uff43\uff4f\uff4c\uff41\u76e3\u4fee\n\u30e2\u30c7\u30eb\u2606\u304a\u3057\u3083\u308c\u30aa\u30fc\u30c7\u30a3\u30b7\u30e7\u30f3\uff12": [
-        "ANLJ"
-    ],
-    "\u30d7\u30ea\u30c6\u30a3\u30fc\u30ea\u30ba\u30e0\n\u30de\u30a4\u2606\u30c7\u30b3\u30ec\u30a4\u30f3\u30dc\u30fc\u30a6\u30a8\u30c7\u30a3\u30f3\u30b0": [
-        "APTJ"
-    ],
-    "\u30af\u30c3\u30ad\u30f3\u30b0\u30de\u30de\uff14": [
-        "ACQJ"
-    ],
-    "\u30b8\u30e5\u30a8\u30eb\u30de\u30b9\u30bf\u30fc": [
-        "AJ5J"
-    ],
-    "\u30ed\u30b9\u30c8\u30d2\u30fc\u30ed\u30fc\u30ba": [
-        "ALHJ"
-    ],
-    "\u30e9\u30d3\u30ea\u30f3\u30b9\u306e\u5f7c\u65b9": [
-        "ALVJ"
-    ],
-    "\u96f7\u5b50\u2010\u7d3a\u78a7\u306e\u7ae0\u2010": [
-        "ARPJ"
-    ],
-    "\u4e0a\u6d77\uff13\uff24\u30ad\u30e5\u30fc\u30d6": [
-        "ASHJ"
-    ],
-    "\u6f22\u691c\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
-        "AXFJ"
-    ],
-    "\u661f\u971c\u306e\u30a2\u30de\u30be\u30cd\u30b9": [
-        "AZSJ"
-    ],
-    "\u30af\u30c3\u30ad\u30f3\u30b0\u30de\u30de\uff15": [
-        "BC5J"
-    ],
-    "\u30d2\u30fc\u30ed\u30fc\u30d0\u30f3\u30af\uff12": [
-        "BNKJ"
-    ],
-    "\u30b3\u30fc\u30d7\u30b9\u30d1\u30fc\u30c6\u30a3\u30fc \uff22\uff32": [
-        "BCPJ"
-    ],
-    "\u4e21\u76ee\u3067\u53f3\u8133\u3092\u935b\u3048\u308b \uff13\uff24\u901f\u8aad\u8853": [
-        "ASKJ"
-    ],
-    "\u30c7\u30a3\u30b9\u30af\u2022\u30a6\u30a9\u30fc\u30ba:\u30a2\u30d9\u30f3\u30b8\u30e3\u30fc\u30ba\n\u30a2\u30eb\u30c6\u30a3\u30e1\u30c3\u30c8\u30d2\u30fc\u30ed\u30fc\u30ba": [
-        "AVNJ"
-    ],
-    "\u30a6\u30a4\u30eb\u30b9\u30b7\u30e5\u30fc\u30bf\u30fcXX": [
-        "AV4J"
-    ],
-    "\u30ed\u30b9\u30c8\u30d2\u30fc\u30ed\u30fc\u30ba\uff12\nPREMIUM EDITION": [
-        "BL3J"
-    ],
-    "\u30af\u30ec\u30e8\u30f3\u3057\u3093\u3061\u3083\u3093\n\u5b87\u5b99DE\u30a2\u30c1\u30e7\u30fc!?": [
-        "ACHJ"
-    ],
-    "\u30c7\u30b8\u30e2\u30f3\u30e6\u30cb\u30d0\u30fc\u30b9\n\u30a2\u30d7\u30ea\u30e2\u30f3\u30b9\u30bf\u30fc\u30ba": [
-        "AUDJ"
-    ],
-    "\u6226\u95d8\u4e2d\u3000\u4f1d\u8aac\u306e\u5fcd\u3068\n\u30b5\u30d0\u30a4\u30d0\u30eb\u30d0\u30c8\u30eb\uff01": [
-        "BCBJ"
-    ],
-    "\u30a2\u30a4\u30ab\u30c4\u30b9\u30bf\u30fc\u30ba\uff01\n\uff2d\uff59\u30b9\u30da\u30b7\u30e3\u30eb\u30a2\u30d4\u30fc\u30eb": [
-        "AKFJ"
-    ],
-    "\u6843\u592a\u90ce\u96fb\u9244\uff12\uff10\uff11\uff17\n\uff5e\u305f\u3061\u3042\u304c\u308c\u65e5\u672c\uff01\uff01\uff5e": [
-        "AKQJ"
-    ],
-    "\u5fcd\u8005\u3058\u3083\u3058\u3083\u4e38\u304f\u3093\n\u3055\u304f\u3089\u59eb\u3068\u706b\u7adc\u306e\u3072\u307f\u3064": [
-        "ANNJ"
-    ],
-    "\u30aa\u30fc\u30eb\u4eee\u9762\u30e9\u30a4\u30c0\u30fc\n\u30e9\u30a4\u30c0\u30fc\u30ec\u30dc\u30ea\u30e5\u30fc\u30b7\u30e7\u30f3": [
-        "ARUJ"
-    ],
-    "\u9003\u8d70\u4e2d\u3000\u53f2\u4e0a\u6700\u5f37\u306e\n\u30cf\u30f3\u30bf\u30fc\u305f\u3061\u304b\u3089\u306b\u3052\u304d\u308c\uff01": [
-        "ATCJ"
-    ],
-    "\u30af\u30ec\u30e8\u30f3\u3057\u3093\u3061\u3083\u3093\n\u6fc0\u30a2\u30c4\uff01\u304a\u3067\u3093\u308f\uff5e\u308b\u3069\u5927\u30b3\u30f3\u4e71!!": [
-        "BWKJ"
-    ],
-    "\u30af\u30ec\u30e8\u30f3\u3057\u3093\u3061\u3083\u3093\n\u5d50\u3092\u547c\u3076\u3000\u30ab\u30b9\u30ab\u30d9\u6620\u753b\u30b9\u30bf\u30fc\u30ba\uff01": [
-        "BGBJ"
-    ],
-    "\u6226\u56fd\u7121\u53cc\u30af\u30ed\u30cb\u30af\u30eb": [
-        "A66J"
-    ],
-    "\u30a8\u30af\u30b9\u30c8\u30eb\u30fc\u30d1\u30fc\u30ba": [
-        "ALTJ"
-    ],
-    "\u6f22\u691c\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0\uff12": [
-        "B2KJ"
-    ],
-    "\u30ed\u30b9\u30c8\u30d2\u30fc\u30ed\u30fc\u30ba\uff12": [
-        "BL2J"
-    ],
-    "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0 if\n\u767d\u591c\u738b\u56fd": [
-        "BFXJ"
-    ],
-    "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0 if\n\u6697\u591c\u738b\u56fd": [
-        "BFYJ"
-    ],
-    "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0 if": [
-        "BFZJ"
-    ],
-    "\u30a2\u30f3\u30c1\u30a7\u30a4\u30f3\u30d6\u30ec\u30a4\u30ba \u30ec\u30af\u30b9": [
-        "AUCJ"
-    ],
-    "\u30a2\u30f3\u30c1\u30a7\u30a4\u30f3\u30d6\u30ec\u30a4\u30ba \u30a8\u30af\u30b7\u30f4": [
-        "AUXJ"
-    ],
-    "\u5b9f\u6cc1\u30d1\u30ef\u30d5\u30eb\u30d7\u30ed\u91ce\u7403 \u30d2\u30fc\u30ed\u30fc\u30ba\n\u3010\u4f53\u9a13\u7248\u3011": [
-        "AWYJ"
-    ],
-    "\u5b9f\u6cc1\u30d1\u30ef\u30d5\u30eb\u30d7\u30ed\u91ce\u7403 \u30d2\u30fc\u30ed\u30fc\u30ba": [
-        "BPYJ"
-    ],
-    "\u30ac\u30f3\u30c0\u30e0\u30c8\u30e9\u30a4\u30a8\u30a4\u30b8SP": [
-        "BTAJ"
-    ],
-    "\u30ca\u30ca\u30df\u3068\u4e00\u7dd2\u306b\u5b66\u307c\uff01\nEnglish\u4e0a\u9054\u306e\u30b3\u30c4": [
-        "AYVJ"
-    ],
-    "\u308f\u304c\u307e\u307e\u30d5\u30a1\u30c3\u30b7\u30e7\u30f3\nGIRLS MODE\u3000\u3088\u304f\u3070\u308a\u5ba3\u8a00\uff01": [
-        "ACLJ"
-    ],
-    "\u3067\u3093\u3062\u3083\u3089\u3059\u3058\u30fc\u3055\u3093\n\u30681000\u4eba\u306e\u304a\u53cb\u3060\u3061\u90aa": [
-        "ADZJ"
-    ],
-    "\u30b9\u30fc\u30d1\u30fc\u30d6\u30e9\u30c3\u30af\u30d0\u30b9\n\uff13\uff24\u30d5\u30a1\u30a4\u30c8": [
-        "ASBJ"
-    ],
-    "\u30d3\u30c3\u30af\u30ea\u30de\u30f3\u6f22\u719f\u8987\u738b\n\u4e09\u4f4d\u52d5\u4e71\u6226\u5275\u7d00": [
-        "AB9J"
-    ],
-    "\u3046\u3057\u307f\u3064\u30e2\u30f3\u30b9\u30c8\u30eb\u30aa\n\u30ea\u30f3\u30bc\u3068\u9b54\u6cd5\u306e\u30ea\u30ba\u30e0": [
-        "AG3J"
-    ],
-    "\u3082\u306e\u3059\u3054\u304f\u8133\u3092\u935b\u3048\u308b\n\uff15\u5206\u9593\u306e\u9b3c\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
-        "ASRJ"
-    ],
-    "\u30df\u30e9\u30af\u30eb\u3061\u3085\u30fc\u3093\u305a\uff01\n\u30b2\u30fc\u30e0\u3067\u30c1\u30e5\u30fc\u30f3\u30a2\u30c3\u30d7\uff01 \u3060\u30d7\u30f3\uff01": [
-        "BG7J"
-    ],
-    "\u30e9\u30b8\u30a2\u30f3\u30c8\u30d2\u30b9\u30c8\u30ea\u30a2\n\u30d1\u30fc\u30d5\u30a7\u30af\u30c8\u30af\u30ed\u30ce\u30ed\u30b8\u30fc": [
-        "BRBJ"
-    ],
-    "\u5973\u306e\u5b50\u3068\u5bc6\u5ba4\u306b\u3044\u305f\u3089\n\u25cb\u25cb\u3057\u3061\u3083\u3046\u304b\u3082\u3057\u308c\u306a\u3044\u3002": [
-        "AWMJ"
-    ],
-    "\u30b9\u30de\u30a4\u30eb\u30d7\u30ea\u30ad\u30e5\u30a2\uff01\n\u30ec\u30c3\u30c4\u30b4\u30fc\uff01\u30e1\u30eb\u30d8\u30f3\u30ef\u30fc\u30eb\u30c9": [
-        "APQJ"
-    ],
-    "\u521d\u5fc3\u8005\u304b\u3089\u65e5\u672c\u4e00\u307e\u3067\n\u305d\u308d\u3070\u3093\u30fb\u3042\u3093\u3056\u3093\u30fb\uff8c\uff97\uff6f\uff7c\uff6d\u6697\u7b97": [
-        "AFUJ"
-    ],
-    "\u59eb\u30ae\u30e3\u30eb\u2665\u30d1\u30e9\u30c0\u30a4\u30b9\n\u30e1\u30c1\u30ab\u30ef\uff01\u30a2\u30b2\u76db\u308a\u2191\uff7e\uff9d\uff7e\uff70\uff7c\uff6e\uff9d\uff01": [
-        "AHGJ"
-    ],
-    "\u30eb\u30a4\u30fc\u30b8\u30de\u30f3\u30b7\u30e7\u30f3\uff12": [
-        "AGGJ"
-    ],
-    "\u82b1\u3068\u3044\u304d\u3082\u306e\u7acb\u4f53\u56f3\u9451": [
-        "ASUJ"
-    ],
-    "\u30e2\u30f3\u30b9\u30bf\u30fc\u30b9\u30c8\u30e9\u30a4\u30af": [
-        "BFLJ"
-    ],
-    "\u3050\u308b\u3050\u308b\u305f\u307e\u3054\u3063\u3061\uff01": [
-        "BGGJ"
-    ],
-    "\u3061\u3083\u304a\u30a4\u30e9\u30b9\u30c8\u30af\u30e9\u30d6": [
-        "BMDJ"
-    ],
-    "\u30d6\u30ec\u30a4\u30d6\u30ea\u30fc\u30bb\u30ab\u30f3\u30c9": [
-        "BSEJ"
-    ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073 \u304d\u304b\u3093\u3057\u3083\n\u30c8\u30fc\u30de\u30b9\u7de8 \u5927\u4e95\u5ddd\u9435\u9053\u3092\u8d70\u308d\u3046\uff01": [
-        "BTGJ"
-    ],
-    "\u3068\u3073\u3060\u3059\uff01\u30d1\u30ba\u30eb\u30dc\u30d6\u30eb3D": [
-        "ABBJ"
-    ],
-    "\u30d0\u30f3\u30c0\u30a4\u30ca\u30e0\u30b3\u30b2\u30fc\u30e0\u30b9PRESENTS\nJ\u30ec\u30b8\u30a7\u30f3\u30c9\u5217\u4f1d": [
-        "BNGJ"
-    ],
-    "\u904a\u3093\u3067\u5c06\u68cb\u304c\u5f37\u304f\u306a\u308b\uff01\n\u9280\u661f\u5c06\u68cbDX": [
-        "BSGJ"
-    ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u8fd1\u6c5f\u9244\u9053\u7de8": [
-        "ATJJ"
-    ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u53e1\u5c71\u96fb\u8eca\u7de8": [
-        "BEDJ"
-    ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u4f1a\u6d25\u9244\u9053\u7de8": [
-        "BTXJ"
-    ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u9577\u826f\u5ddd\u9244\u9053\u7de8": [
-        "ARJJ"
-    ],
-    "\u304a\u3055\u308f\u308a\u63a2\u5075\u3000\u5c0f\u6ca2\u91cc\u5948\n\u306a\u3081\u3053\u30ea\u30ba\u30e0": [
-        "BSLJ"
-    ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u3086\u3044\u30ec\u30fc\u30eb\u7de8": [
-        "BTYJ"
-    ],
-    "\u30dd\u30b1\u30c3\u30c8\u30b5\u30c3\u30ab\u30fc\u30ea\u30fc\u30b0\n\u30ab\u30eb\u30c1\u30e7\u30d3\u30c3\u30c8": [
-        "AHBJ"
-    ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u9e7f\u5cf6\u81e8\u6d77\u9244\u9053\u7de8": [
-        "ARKJ"
-    ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u4e0a\u6bdb\u96fb\u6c17\u9244\u9053\u7de8": [
-        "BTJJ"
-    ],
-    "\u84bc\u304d\u96f7\u9706\u3000\u30ac\u30f3\u30f4\u30a9\u30eb\u30c8\n\u30b9\u30c8\u30e9\u30a4\u30ab\u30fc\u30d1\u30c3\u30af": [
-        "BG8J"
-    ],
-    "\u30a2\u30f3\u30d1\u30f3\u30de\u30f3\u3068\u30bf\u30c3\u30c1\u3067\n\u308f\u304f\u308f\u304f\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
-        "BWTJ"
-    ],
-    "\u50d5\u306e\u30d2\u30fc\u30ed\u30fc\u30a2\u30ab\u30c7\u30df\u30a2\n\u30d0\u30c8\u30eb\u30fb\u30d5\u30a9\u30fc\u30fb\u30aa\u30fc\u30eb": [
-        "BHAJ"
-    ],
-    "\u30d6\u30ec\u30a4\u30d6\u30ea\u30fc\u30c7\u30d5\u30a9\u30eb\u30c8\n\u30d5\u30a9\u30fc\u30b6\u30fb\u30b7\u30fc\u30af\u30a6\u30a7\u30eb": [
-        "BTRJ"
-    ],
-    "\u8b0e\u89e3\u304d\u30d0\u30c8\u30eb\uff34\uff2f\uff32\uff25\uff01\n\u4f1d\u8aac\u306e\u9b54\u5bae\u3092\u5fa9\u6d3b\u3055\u305b\u3088\uff01": [
-        "BREJ"
-    ],
-    "\u30d6\u30ec\u30a4\u30d6\u30ea\u30fc\u30c7\u30d5\u30a9\u30eb\u30c8": [
-        "AFFJ"
-    ],
-    "\u5275\u4f5c\u30a2\u30ea\u30b9\u3068\u738b\u5b50\u3055\u307e\uff01": [
-        "ARZJ"
-    ],
-    "\u30c0\u30f3\u30dc\u30fc\u30eb\u6226\u6a5f\uff37\uff21\uff32\uff33": [
-        "BDNJ"
-    ],
-    "\u30dd\u30dd\u30ed\u30af\u30ed\u30a4\u30b9\u7267\u5834\u7269\u8a9e": [
-        "BPPJ"
-    ],
-    "\u304a\u305d\u677e\u3055\u3093\u3000\u677e\u307e\u3064\u308a\uff01": [
-        "BW3J"
-    ],
-    "\u5c0f\u6797\u304c\u53ef\u611b\u3059\u304e\u3066\u30c4\u30e9\u30a4\u3063!!": [
-        "BKQJ"
-    ],
-    "\u30c9\u30e9\u30a4\u30d0\u30fc\uff1a\u30ec\u30cd\u30b2\u30a4\u30c9\uff13D": [
-        "ADRJ"
-    ],
-    "\u7a7a\u9593\u3055\u304c\u3057\u3082\u306e\u7cfb\u8133\u529b\u958b\u767a\n\uff13\uff24\u8133\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
-        "AKTJ"
-    ],
-    "\u5927\u6226\u7565\u3000\u5927\u6771\u4e9c\u8208\u4ea1\u53f2\uff24\uff38\n\uff5e\u7b2c\u4e8c\u6b21\u4e16\u754c\u5927\u6226\uff5e": [
-        "BFEJ"
-    ],
-    "\u30cf\u30ed\u30fc\u30ad\u30c6\u30a3\u3068\u3044\u3063\u3057\u3087\uff01\n\u30d6\u30ed\u30c3\u30af\u30af\u30e9\u30c3\u30b7\u30e5\uff3a": [
-        "AHZJ"
-    ],
-    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u3000\u5927\u6d77\u7269\u8a9e\uff12\n\uff5e\u30d1\u30c1\u30d7\u30ed\u98a8\u96f2\u9332\u30fb\u82b1\uff5e": [
-        "AU3J"
-    ],
-    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u3000\u5927\u6d77\u7269\u8a9e\uff12\n\uff37\uff49\uff54\uff48\u3000\u30a2\u30b0\u30cd\u30b9\u30fb\u30e9\u30e0": [
-        "AU2J"
-    ],
-    "\u30c7\u30a3\u30ba\u30cb\u30fc\u30a4\u30f3\u30d5\u30a3\u30cb\u30c6\u30a3\n\u30c8\u30a4\u30fb\u30dc\u30c3\u30af\u30b9\u30fb\u30c1\u30e3\u30ec\u30f3\u30b8": [
-        "ADYJ"
-    ],
-    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30eb\u30d2\u30fc\u30ed\u30fc\u30ba\n\u30a2\u30eb\u30c6\u30a3\u30e1\u30c3\u30c8\u30df\u30c3\u30b7\u30e7\u30f3\uff38": [
-        "BD9J"
-    ],
-    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30eb\u30d2\u30fc\u30ed\u30fc\u30ba\n\u30a2\u30eb\u30c6\u30a3\u30e1\u30c3\u30c8\u30df\u30c3\u30b7\u30e7\u30f3\uff12": [
-        "BDBJ"
-    ],
-    "\u5263\u3068\u9b54\u6cd5\u3068\u5b66\u5712\u30e2\u30ce\u3002\uff13\uff24": [
-        "AKNJ"
-    ],
-    "\u307f\u3093\u306a\u3067\u30aa\u30fc\u30c8\u30ec\u30fc\u30b9\uff13\uff24": [
-        "ARCJ"
-    ],
-    "\u30b9\u30fc\u30d1\u30fc\u30ed\u30dc\u30c3\u30c8\u5927\u6226\uff35\uff38": [
-        "AS6J"
-    ],
-    "\u30c9\u30ea\u30fc\u30e0\u30ac\u30fc\u30eb\u3000\u30d7\u30eb\u30df\u30a8": [
-        "BMVJ"
-    ],
-    "\u30b9\u30fc\u30d1\u30fc\u30ed\u30dc\u30c3\u30c8\u5927\u6226\uff22\uff38": [
-        "BSRJ"
-    ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3\uff11\u30fb\uff12\u30fb\uff13!!\n\u5186\u5802\u5b88\u4f1d\u8aac": [
-        "AETJ"
-    ],
-    "\uff27\uff4f\uff01\u30d7\u30ea\u30f3\u30bb\u30b9\u30d7\u30ea\u30ad\u30e5\u30a2\n\u30b7\u30e5\u30ac\u30fc\u738b\u56fd\u30686\u4eba\u306e\u30d7\u30ea\u30f3\u30bb\u30b9\uff01": [
-        "BG5J"
-    ],
-    "\u30c8\u30fc\u30de\u30b9\u3068\u3042\u305d\u3093\u3067\u304a\u307c\u3048\u308b\n\u3053\u3068\u3070\u3068\u304b\u305a\u3068ABC": [
-        "BTFJ"
-    ],
-    "\u7363\u96fb\u6226\u968a\u30ad\u30e7\u30a6\u30ea\u30e5\u30a6\u30b8\u30e3\u30fc\n\u30b2\u30fc\u30e0\u3067\u30ac\u30d6\u30ea\u30f3\u30c1\u30e7\uff01\uff01": [
-        "AAKJ"
-    ],
-    "\u30ac\u30fc\u30eb\u30ba\u30d5\u30a1\u30c3\u30b7\u30e7\u30f3\uff13\uff24\u2606\n\u3081\u3056\u305b\uff01\u30c8\u30c3\u30d7\u30b9\u30bf\u30a4\u30ea\u30b9\u30c8": [
-        "AGUJ"
-    ],
-    "\u304b\u308f\u3044\u3044\u30da\u30c3\u30c8\u3068\u304f\u3089\u305d\u3046\uff01\n\u308f\u3093\u30cb\u30e3\u30f3\uff06\u30df\u30cb\u30df\u30cb\u30a2\u30cb\u30de\u30eb": [
-        "BHSJ"
-    ],
-    "\u304b\u308f\u3044\u3044\u30da\u30c3\u30c8\u3068\u304f\u3089\u305d\u3046\uff01\n\u308f\u3093\u30cb\u30e3\u30f3\uff06\u30a2\u30a4\u30c9\u30eb\u30a2\u30cb\u30de\u30eb": [
-        "BWAJ"
-    ],
-    "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0\u3000\u899a\u9192": [
-        "AFEJ"
-    ],
-    "\u5927\u5408\u594f\uff01\u30d0\u30f3\u30c9\u30d6\u30e9\u30b6\u30fc\u30ba\uff30": [
-        "ANEJ"
-    ],
-    "\u304a\u3055\u308f\u308a\u63a2\u5075\u3000\u306a\u3081\u3053\u5927\u7e41\u6b96": [
-        "APMJ"
-    ],
-    "\u771f\u30fb\u5973\u795e\u8ee2\u751f\u2163\u3000\uff26\uff29\uff2e\uff21\uff2c": [
-        "BG4J"
-    ],
-    "\u30cf\u30d4\u30cd\u30b9\u30c1\u30e3\u30fc\u30b8\u30d7\u30ea\u30ad\u30e5\u30a2\uff01\n\u304b\u308f\u30eb\u30f3\u2606\u30b3\u30ec\u30af\u30b7\u30e7\u30f3": [
-        "BHCJ"
-    ],
-    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u30d7\u30ec\u30df\u30a2\u30e0\u6d77\u7269\u8a9e\n\uff5e\u5922\u898b\u308b\u4e59\u5973\u3068\u30d1\u30c1\u30f3\u30b3\u738b\u6c7a\u5b9a\u6226\uff5e": [
-        "AUMJ"
-    ],
-    "\u6226\u56fd\u7121\u53cc\u30af\u30ed\u30cb\u30af\u30eb\u3000\u30bb\u30ab\u30f3\u30c9": [
-        "AZCJ"
-    ],
-    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30eb\u30d5\u30e5\u30fc\u30b8\u30e7\u30f3\u30ba": [
-        "BDLJ"
-    ],
-    "\u30c8\u30e2\u30c0\u30c1\u30b3\u30ec\u30af\u30b7\u30e7\u30f3\u3000\u65b0\u751f\u6d3b": [
-        "EC6J"
-    ],
-    "\u30e2\u30c7\u30eb\u2606\u304a\u3057\u3083\u308c\u30aa\u30fc\u30c7\u30a3\u30b7\u30e7\u30f3\n\u30d7\u30e9\u30c1\u30ca": [
-        "AN9J"
-    ],
-    "\u30aa\u30b7\u30e3\u30ec\u3067\u304b\u308f\u3044\u3044\u5b50\u72ac\u3068\u904a\u307c\uff01\n\uff0d\u6d77\u7de8\uff0d": [
-        "APIJ"
-    ],
-    "\u30aa\u30b7\u30e3\u30ec\u3067\u304b\u308f\u3044\u3044\u5b50\u72ac\u3068\u904a\u307c\uff01\n\uff0d\u8857\u7de8\uff0d": [
-        "APOJ"
-    ],
-    "\u30e2\u30c7\u30eb\u2606\u304a\u3057\u3083\u308c\u30aa\u30fc\u30c7\u30a3\u30b7\u30e7\u30f3\n\u30c9\u30ea\u30fc\u30e0\u30ac\u30fc\u30eb": [
-        "AYCJ"
-    ],
-    "\u30cf\u30ed\u30fc\u30ad\u30c6\u30a3\u3068\u307e\u307b\u3046\u306e\u30a8\u30d7\u30ed\u30f3\n\u30ea\u30ba\u30e0\u30af\u30c3\u30ad\u30f3\u30b0\u266a": [
-        "BHKJ"
-    ],
-    "\uff2d\uff2f\uff25\uff2d\uff2f\uff25\uff24\uff21\uff29\uff33\uff25\uff2e\uff33\uff2f\uff35\n\uff27\uff25\uff2e\uff24\uff21\uff29\uff22\uff21\uff2e\uff13\uff24": [
-        "AMAJ"
-    ],
-    "\u306d\u3089\u3063\u3066\uff01\u3068\u3070\u3057\u3066\uff01\u30ea\u30e9\u30c3\u30af\u30de\n\u3050\u3089\u3050\u3089\u30b9\u30a4\u30fc\u30c4\u30bf\u30ef\u30fc": [
-        "ARLJ"
-    ],
-    "\u30c9\u30e9\u3048\u3082\u3093\u3000\u306e\u3073\u592a\u306e\u5b87\u5b99\u82f1\u96c4\u8a18\n\uff08\u30b9\u30da\u30fc\u30b9\u30d2\u30fc\u30ed\u30fc\u30ba\uff09": [
-        "BS5J"
-    ],
-    "\u30c7\u30a3\u30ba\u30cb\u30fc\u3000\u30de\u30b8\u30c3\u30af\u30ad\u30e3\u30c3\u30b9\u30eb\n\u30de\u30a4\u30fb\u30cf\u30c3\u30d4\u30fc\u30fb\u30e9\u30a4\u30d5\uff12": [
-        "BD2J"
-    ],
-    "\u305f\u307e\u3054\u3063\u3061\u306e\u30d7\u30c1\u30d7\u30c1\u304a\u307f\u305b\u3063\u3061\n\uff5e\u306b\u3093\u304d\u306e\u304a\u307f\u305b\u3042\u3064\u3081\u307e\u3057\u305f\uff5e": [
-        "BT4J"
-    ],
-    "\u3073\u3063\u304f\u308a\uff01\u3068\u3073\u3060\u3059\uff01\u9b54\u6cd5\u306e\u30da\u30f3": [
-        "AMPJ"
-    ],
-    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u3000\u30c7\u30e9\u30c3\u30af\u30b9\u6d77\u7269\u8a9e": [
-        "AU9J"
-    ],
-    "\u30b2\u30fc\u30e0\u30bb\u30f3\u30bf\u30fc\uff23\uff38\uff13\u4e01\u76ee\u306e\u6709\u91ce": [
-        "BCXJ"
-    ],
-    "\u30c6\u30f3\u30ab\u30a4\u30ca\u30a4\u30c8\u3000\u30d6\u30ec\u30a4\u30d6\u30d0\u30c8\u30eb": [
-        "BTKJ"
-    ],
-    "\u30d7\u30ea\u30c6\u30a3\u30fc\u30ea\u30ba\u30e0\u30ec\u30a4\u30f3\u30dc\u30fc\u30e9\u30a4\u30d6\n\u304d\u3089\u304d\u3089\u30de\u30a4\u2606\u30c7\u30b6\u30a4\u30f3": [
-        "BP2J"
-    ],
-    "\u30c1\u30e7\u30b3\u72ac\u306e\u3061\u3087\u3053\u3063\u3068\u4e0d\u601d\u8b70\u306a\u7269\u8a9e\n\u30b7\u30e7\u30b3\u30e9\u59eb\u3068\u9b54\u6cd5\u306e\u30ec\u30b7\u30d4": [
-        "BCHJ"
-    ],
-    "\u305d\u308d\u3070\u3093\u30fb\u3042\u3093\u3056\u3093\u30fb\uff8c\uff97\uff6f\uff7c\uff6d\u6697\u7b97\n\u5b8c\u5168\u7248": [
-        "BSAJ"
-    ],
-    "\u30b9\u30e9\u30a4\u30e0\u3082\u308a\u3082\u308a\u30c9\u30e9\u30b4\u30f3\u30af\u30a8\u30b9\u30c8\uff13\n\u5927\u6d77\u8cca\u3068\u3057\u3063\u307d\u56e3": [
-        "AMRJ"
-    ]
+    "100％ PASUKARU SENSEI PPB": ["BP4J"],
+    "12 SAI KOISURU Diary": ["BA7J"],
+    "12 SAI TOROKERU Puzzle": ["A2PJ"],
+    "12 SAI": ["BTVJ"],
+    "2-Pack": ["BF6Z"],
+    "2in1: Horses 3D": ["BMFP"],
+    "2in1:Horses+Pet3D": ["BMXP"],
+    "2in1:Vet3D+Pet3D": ["BELP"],
+    "35 Classic Games": ["AF5P"],
+    "3D Game Collection": ["AD3D", "AD3P"],
+    "3D MahJongg": ["AG2P"],
+    "3in1 Horses": ["BRZP"],
+    "4 Elements": ["AELP"],
+    "50 Classic Games 3D": ["AF6Z"],
+    "50 Classic Games": ["AC5E", "AF6P"],
+    "7TH DRAGON III CODE: VFD": ["BD7E", "BD7P"],
+    "7TH DRAGON Ⅲ code:VFD": ["BD7J"],
+    "A Penguin's Troubles +": ["AYSJ"],
+    "A-Train 3D NEO": ["BN3J"],
+    "A-Train 3D": ["AALJ"],
+    "ACE COMBAT 3D": ["AC3J"],
+    "ACE COMBAT AH LEGACY +": ["BCRE", "BCRP"],
+    "ACECOMBAT 3D +": ["BCRJ"],
+    "ACNL - Welcome amiibo": ["EAAE", "EAAJ", "EAAP"],
+    "AIKATSU! Cinderella Lesson": ["AEKJ"],
+    "AKB48+Me": ["AKBJ"],
+    "ALLIANCE ALIVE": ["AL4J"],
+    "ASSAULT HORIZON LEGACY": ["AC3E", "AC3P"],
+    "AT:  FJI": ["BFNE", "BFNP"],
+    "AT:TSotNK": ["AVTE", "AVTP"],
+    "AT": ["AVTJ"],
+    "AYSTA5G?": ["BY5E"],
+    "AZITO 3D": ["AZTJ"],
+    "AZURE STRIKER GUNVOLT: SP": ["BG8E"],
+    "Adventure Time: ETDBIDK": ["AY9E", "AY9P"],
+    "Adventure Time™ Hey Ice King!": ["AD4E"],
+    "Alien Chaos 3D": ["AM2E"],
+    "Amazing Spider-Man 2™": ["AXYE", "AXYP"],
+    "Ame no Mihashira Kai": ["BAMJ"],
+    "American Mensa Academy": ["AMME"],
+    "Angry Birds Star Wars": ["ANDE", "ANDP"],
+    "Angry Birds Trilogy": ["ANGE", "ANGP"],
+    "Animal Crossing New Leaf": ["EGDJ", "EGDK"],
+    "Animal Crossing: New Leaf": ["EGDE", "EGDP"],
+    "Animal Hospital": ["AZFP"],
+    "Anpanman new aiueo kyoushitsu": ["AEWJ"],
+    "Apollo Justice: Ace Attorney": ["AXRJ"],
+    "Arkham Origins Blackgate": ["AZEE", "AZEP"],
+    "Art Academy": ["AACE"],
+    "Asphalt 3D: Nitro Racing": ["ASFJ"],
+    "Asphalt 3D": ["ASFE", "ASFP"],
+    "Asterix": ["BMNP"],
+    "Atlantic Quest": ["BAQP"],
+    "Atooi Collection": ["AUTE"],
+    "Attack on Titan Escape": ["AEVJ"],
+    "Azada": ["AZDP"],
+    "BEASTSAGA": ["BEAJ"],
+    "BEN 10 OMNIVERSE™ 2": ["AEQE", "AEQP"],
+    "BEN 10 OMNIVERSE™": ["ABVE", "ABVP"],
+    "BEYBLADE EVOLUTION": ["ARXE", "ARXP", "BBBJ"],
+    "BF-My Horse 3D": ["BMEP"],
+    "BIOHAZARD  MERCENARIES": ["ABMJ"],
+    "BIOHAZARD REVELATIONS": ["ABRJ", "ABRK", "ABRW"],
+    "BIT.TRIP SAGA": ["ABTE", "ABTP"],
+    "BLAZBLUE CS Ⅱ": ["ABLJ", "ABLP", "ABLZ"],
+    "BRAVE COMPANY": ["AYGJ"],
+    "BRAVELY DEFAULT": ["BTRE", "BTRP"],
+    "BRAVELY SECOND": ["BSED", "BSEE"],
+    "BUST-A-MOVE UNIVERSE": ["ABBE"],
+    "Barbie Puppy 2015": ["BRQE", "BRQP", "BRQZ"],
+    "Barbie": ["AAVE", "AAVP"],
+    "Barbie™ GGP": ["ABYE", "ABYP"],
+    "Battleship™": ["ABSE", "ABSP"],
+    "Beautician debut story": ["BYCJ"],
+    "Bella Sara 2": ["AY7P"],
+    "Bella Sara": ["AB2P"],
+    "Ben 10™ Galactic Racing": ["ABNE", "ABNP"],
+    "Best in Breed 3D™": ["ALDE"],
+    "Best of Arcade Games": ["AYHP"],
+    "Best of Board Games": ["AYFP"],
+    "Best of Casual Games": ["BCSP"],
+    "Bibi&Tina": ["BBTD"],
+    "BonBon Ribbon": ["AVRJ"],
+    "Boulder Dash®-XL 3D™": ["ABZE", "ABZP"],
+    "Bowling Bonanza 3D": ["AB6P"],
+    "Brain Age Concentration Training": ["ASRE"],
+    "Brain Training 3D": ["AKTP"],
+    "Bratz® 2012": ["AB5E"],
+    "Brilliant Hamsters!": ["AHMJ"],
+    "Brunswick Pro Bowling": ["ABWE"],
+    "Buddyfight BuddyChampion": ["BFAJ"],
+    "Buddyfight Strongest": ["BFBJ"],
+    "CARDFIGHT!! Vanguard LOV": ["BVGJ"],
+    "CARDFIGHT!! Vanguard RTV": ["AVGJ"],
+    "CN Punch Time Explosion": ["ACNE", "ACNP"],
+    "CNBC": ["BRWE", "BRWZ"],
+    "CODE OF PRINCESS": ["AC7E", "AC7J"],
+    "CONCEPTIONⅡ": ["BCCJ"],
+    "CRASH CITY MAYHEM": ["AC2E"],
+    "CRAZY CONSTRUCTION": ["BCZP"],
+    "CRUSH™3D": ["ACRE", "ACRJ", "ACRP"],
+    "Camaro™Wild Ride": ["ACWP"],
+    "Candy Match 3": ["BCMP"],
+    "Captain America™": ["ACAE", "ACAP"],
+    "Captain Toad: Treasure Tracker": ["BZPE", "BZPJ", "BZPP"],
+    "Cars 2": ["AAZE", "AAZP", "AAZZ"],
+    "Cartoon Universe: Adventure": ["BCUE"],
+    "Cartoonist debut story": ["BGHJ"],
+    "Cats & Dogs": ["AHUP"],
+    "Cave Story 3D": ["ACVE", "ACVP"],
+    "Centipede: Infestation": ["ACPE"],
+    "Chara Pet": ["BKPJ"],
+    "Chibi-Robo! Zip Lash": ["BXLE", "BXLJ", "BXLP"],
+    "Classic Games Overload": ["ACGE"],
+    "Classics": ["ARDP"],
+    "Cloudy 2": ["AD5E", "AD5P", "AD5Z"],
+    "Cocoto Alien Brick Breaker": ["AB7P"],
+    "Code Name: S.T.E.A.M.": ["AY6A"],
+    "Combat of Giants": ["ATTE", "ATTJ", "ATTP"],
+    "Conan\u3000Marionettesymphony": ["BKNJ"],
+    "Conception II": ["BCCE"],
+    "Cooking Mama 5: Bon Appetit!": ["BC5E"],
+    "Cooking Mama: Bon Appétit!": ["BC5P"],
+    "Cooking Mama: Sweet Shop": ["BS8E", "BS8P"],
+    "Corpse Party": ["BCPE"],
+    "Cradle of Egypt 2 3D": ["AJEE", "AJEF", "AJEP"],
+    "Cradle of Rome 2": ["AJLE", "AJLP", "AJLZ"],
+    "Crash Time 3D": ["AFBP"],
+    "Crosswords Plus": ["AQ8E"],
+    "Cube Creator DX": ["A9CJ"],
+    "Cubic Ninja": ["AQNE", "AQNJ", "AQNP"],
+    "Culdcept Revolt": ["AY3E", "AY3J", "AY3P"],
+    "Culdcept": ["ACBJ"],
+    "Cut the Rope® Triple Treat": ["BR3E", "BR3P"],
+    "DBZ 超究極武闘伝": ["BDVJ"],
+    "DBZ: Extreme Butoden": ["BDVE", "BDVP"],
+    "DEAD OR ALIVE Dimensions": ["ADDE", "ADDJ", "ADDP"],
+    "DECA SPORTA": ["ADEJ"],
+    "DECA SPORTS EXTREME": ["ADEE"],
+    "DEEP STRANGE JOURNEY": ["AJ9J"],
+    "DETECTIVE CONAN": ["BKRJ"],
+    "DK Country Returns 3D": ["AYTE", "AYTP"],
+    "DK Returns 3D": ["AYTJ"],
+    "DQM2": ["BDMJ"],
+    "DQMJOKER3 PRO": ["BDQJ"],
+    "DQMJOKER3": ["BJ3J"],
+    "DQMT": ["ATWJ"],
+    "DRAGON BALL FUSIONS": ["BDLE", "BDLP"],
+    "DRAGON QUEST VII": ["AD7E", "AD7J", "AD7P"],
+    "DRAGON QUEST XI": ["BTZJ"],
+    "Deer Drive Legends": ["AD2E"],
+    "Derby Stallion GOLD": ["BDSJ"],
+    "Detective Pikachu": ["A98A", "A98A"],
+    "Devil Summoner: Soul Hackers": ["AHQE", "AHQJ", "AHQP"],
+    "Devil Survivor 2": ["ADXE", "ADXP"],
+    "Devilish Brain Training": ["ASRP", "ASRW"],
+    "Die drei ??? Kids": ["BD4D"],
+    "Dillon's Dead-Heat Breakers": ["A9EJ", "A9EP"],
+    "Dire Grove": ["ADHP"],
+    "Disney Art Academy": ["BWDE", "BWDJ", "BWDP"],
+    "Disney Big Hero 6": ["BH6E", "BH6P", "BH6Z"],
+    "Disney Frozen-BH6 Combo": ["BF6E"],
+    "Disney Frozen: Olaf's Quest": ["AEHE", "AEHJ", "AEHP"],
+    "Disney Frozen": ["AEHZ"],
+    "Disney Infinity": ["ADYE", "ADYP", "ADYZ"],
+    "Disney Magic Castle": ["AMQJ"],
+    "Disney Magical World 2": ["BD2E", "BD2P"],
+    "Disney Magical World": ["AMQE", "AMQP"],
+    "Disney Planes 2": ["BPRE", "BPRP"],
+    "Disney Planes": ["APNE", "APNP", "APNR", "APNY", "APNZ"],
+    "Disney Princess": ["ADPE", "ADPP", "ADPX"],
+    "Disney Violetta": ["BGRP"],
+    "Disney Wreck-It Ralph": ["AWRE", "AWRP"],
+    "Doctor Lautrec": ["ADLE", "ADLJ", "ADLP"],
+    "DokiDoki! Precure": ["BPQJ"],
+    "Dolly Kanon": ["BJWJ"],
+    "Dorachie": ["BDCJ"],
+    "Doraeigo": ["BDEJ"],
+    "Doraemon": ["ADWW"],
+    "Doragana": ["BDAJ"],
+    "Doramoji": ["BKVJ"],
+    "Dorothy's Return": ["BDTE", "BDTP"],
+    "Downtown Nekketsu Jidaigeki": ["BNJJ"],
+    "Dragon Ball Heroes": ["ADGJ"],
+    "Dragon Quest VIII": ["BQ8E", "BQ8J", "BQ8P"],
+    "Dragons 2": ["BTDE", "BTDP"],
+    "Dream Trigger™ 3D": ["ADTE", "ADTP"],
+    "DreamWorks Combo Pack": ["AGCP"],
+    "DreamWorks SS Kartz": ["AKZE", "AKZP"],
+    "Driver® Renegade": ["ADRE", "ADRP"],
+    "DualPenSports": ["APPE", "APPP"],
+    "Duck Dynasty®": ["BDKE"],
+    "Dynasty Warriors VS": ["AS5J"],
+    "EO V: BEYOND THE MYTH": ["BMZP"],
+    "EO V: Beyond the Myth": ["BMZE"],
+    "ESSEらくらく家計簿": ["AEZJ"],
+    "ETRIAN MYSTERY DUNGEON": ["BFDE"],
+    "EXSTETRA": ["BEXJ"],
+    "Earthpedia": ["AEPJ"],
+    "El prof. Layton y el legado...": ["AL6S"],
+    "El prof. Layton y la máscara...": ["AKKS"],
+    "Elminage Gothic 3D REMIX": ["AEUJ"],
+    "Etrian Mystery Dungeon": ["BFDP"],
+    "Etrian Odyssey 2 Untold": ["BM9E", "BM9P"],
+    "Etrian Odyssey IV": ["ASJE", "ASJP"],
+    "Etrian Odyssey Nexus": ["BZME", "BZMP"],
+    "Etrian Odyssey Untold 2": ["BM9J"],
+    "Etrian Odyssey Untold": ["BSKE", "BSKJ", "BSKP"],
+    "Etrian Odyssey V": ["BMZJ"],
+    "Etrian Odyssey X": ["BZMJ"],
+    "Ever Oasis": ["BAGE", "BAGJ", "BAGP"],
+    "F1 2011": ["AF4E", "AF4J", "AF4P"],
+    "FANTASY LIFE LINK!": ["BLKJ"],
+    "FANTASY LIFE": ["AFLJ"],
+    "FE Echoes: Shadows of Valentia": ["AJJE", "AJJK", "AJJP"],
+    "FEDERATION FORCE": ["BCAE", "BCAJ", "BCAP"],
+    "FIFA 12": ["AF2D", "AF2P"],
+    "FIFA 13": ["AF8D", "AF8P"],
+    "FIFA 14": ["AFYD", "AFYP"],
+    "FIFA 15": ["BFTD", "BFTP"],
+    "FIFA Soccer 12": ["AF2E"],
+    "FIFA Soccer 13": ["AF8E"],
+    "FIFA Soccer 14": ["AFYE"],
+    "FIFA Soccer 15": ["BFTE"],
+    "FINAL FANTASY  EXPLORERS": ["BCEJ"],
+    "FINAL FANTASY EXPLORERS": ["BCEE", "BCEP"],
+    "FINDING NEMO": ["AF7E", "AF7P", "AF7X"],
+    "FIREMAN SAM": ["AFTP"],
+    "FISH ON": ["AFAJ"],
+    "FS14": ["BFSE", "BFSJ", "BFSP"],
+    "FS18": ["A8FE", "A8FJ", "A8FP"],
+    "FS3D": ["AL3J", "AL3P"],
+    "FabStyle": ["AFVJ"],
+    "Face Racers": ["AFCE"],
+    "Famista2011": ["AFSJ"],
+    "Fantasy Life™": ["AFLE", "AFLP"],
+    "Farmscapes": ["AF9F"],
+    "Fashion Designer 3D": ["AGUP"],
+    "Fashion Designer": ["AGUE"],
+    "Fashion Life": ["AF3E"],
+    "Fashion World 3D": ["AF3P"],
+    "Fast & Furious™: Showdown": ["AFHE", "AFHP"],
+    "Fire Emblem Awakening": ["AFEE"],
+    "Fire Emblem Echoes": ["AJJJ"],
+    "Fire Emblem Fates": ["BFXE", "BFXP", "BFYE", "BFYP", "BFZE", "BFZK", "BFZP"],
+    "Fire Emblem if": ["BFXZ"],
+    "Fire Emblem: Awakening": ["AFEP"],
+    "FishEyes3D": ["ARFJ"],
+    "Flap Flap": ["BFFP"],
+    "Fossil Fighters Frontier": ["AHRD", "AHRE"],
+    "Freakyforms Deluxe": ["ATQE", "ATQP"],
+    "Frogger 3D": ["AFRE", "AFRJ", "AFRP"],
+    "Funassy VS Dragons": ["BF4J"],
+    "Funfair Party Games": ["AFND", "AFNP"],
+    "Funky Barn 3D": ["AFME", "AFMJ", "AFMP"],
+    "Future Card Buddyfight FEF": ["BDYJ"],
+    "G1 Grand Prix": ["AHTJ"],
+    "GAKI": ["BDXJ"],
+    "GE_Adventure": ["AY5J"],
+    "GE_Princess": ["AY4J"],
+    "GGENERATION 3D": ["AGJJ"],
+    "GIRLS MODE 3\u3000キラキラ☆コーデ": ["ECDJ"],
+    "GIRLS MODE\u3000トキメキUP！": ["ACLJ"],
+    "GIRLS MODE\u3000よくばり宣言！": ["ACLJ"],
+    "GUDETAMA2": ["BGJJ"],
+    "GUDETAMA": ["BGLJ"],
+    "GUILD01": ["AG9J"],
+    "GUNDAM THE 3D BATTLE": ["A78J"],
+    "GYROZETTER": ["ABCJ"],
+    "Gabrielle's Ghostly Groove 3D": ["AG3E", "AG3P"],
+    "Gaist Crusher God": ["BGDJ"],
+    "Gaist Crusher": ["AGYJ"],
+    "Games Festival 1": ["AAEP"],
+    "Games Festival 2": ["AAFP"],
+    "Gardening Mama 2": ["BGME"],
+    "Gardening Mama": ["BGMJ"],
+    "Gardening mama": ["BGMP"],
+    "Gardenscapes": ["AG8P"],
+    "Garfield Kart": ["AGPE", "AGPP"],
+    "Gem Smashers": ["AGSE"],
+    "Generator Rex": ["AGXE", "AGXP"],
+    "Ghost Recon Shadow Wars": ["AGRE", "AGRJ", "AGRP"],
+    "Girls Mode 4 スター☆スタイリスト": ["AJBJ"],
+    "Girls' Fashion Shoot": ["ANLD", "ANLE", "ANLP"],
+    "GirlsRPG CindereLife": ["ACJJ"],
+    "Goosebumps: The Game": ["BBME", "BBMP"],
+    "Gravity Falls": ["AGFE", "AGFP"],
+    "Green Lantern™": ["AGLE", "AGLP"],
+    "Gummy Bears": ["AGVP"],
+    "HATSUNE MIKU Project mirai 2": ["AHNJ"],
+    "HATSUNE MIKU Project mirai": ["AM9J"],
+    "HEAVY FIRE THE CHOSEN FEW": ["AHVJ"],
+    "HELLO KITTY 3D RACING": ["BKYE", "BKYP"],
+    "HYRULE WARRIORS LEGENDS": ["BZHE", "BZHJ", "BZHP"],
+    "Hakuoki": ["AH9E", "AH9P"],
+    "Happy Feet 2": ["AHFE", "AHFP"],
+    "Happy Happy Family": ["BHHP"],
+    "Happy Home Designer": ["EDHE", "EDHJ", "EDHP"],
+    "Harvest Moon: A New Beginning": ["ABQE", "ABQP"],
+    "Harvest Moon: Skytree Village": ["AVAE", "AVAP"],
+    "Harvest Moon: The Lost Valley": ["AVME", "AVMP"],
+    "Harvest Moon": ["AT2E", "AT2P"],
+    "Hatsune Miku Project Mirai DX": ["BRXJ"],
+    "Hatsune Miku: Project Mirai DX": ["BRXE", "BRXP"],
+    "Heavy Fire: The Chosen Few": ["AHVE"],
+    "HeavyFireTCF3D": ["AHVP"],
+    "Hello Kitty & the Apron of Magic": ["BHKP"],
+    "Hello Kitty Picnic": ["AHLD", "AHLE"],
+    "Hello Kitty and Friends": ["AHKP", "AHKZ"],
+    "Hello Kitty around the World": ["AHKJ"],
+    "Hello Kitty: Rockin' World Tour": ["BKTJ", "BKTP"],
+    "Hello Kitty": ["AHKE"],
+    "Heroes of Ruin": ["AH6E", "AH6P"],
+    "Hexenbesen-Rennen 2": ["AA3D"],
+    "Hey! Pikmin": ["BRCE", "BRCJ", "BRCP"],
+    "Hollywood Fame": ["AFXP"],
+    "Hometown Story": ["AHXE", "AHXJ", "AHXP"],
+    "Horrid Henry: Bugly": ["AHHP"],
+    "Horse Life 4": ["BH4P"],
+    "Horse Vet 3D": ["BP9P"],
+    "Horses 3D, Vol. 2": ["BMRP"],
+    "Horses 3D, Vol. 3": ["BM2P"],
+    "Horses 3D": ["AHSE"],
+    "Hot Wheels™ WBD": ["AEAE", "AEAP"],
+    "Hotel Transylvania": ["AH8E", "AH8F", "AH8P"],
+    "HyakumasuDorazan": ["BNHJ"],
+    "I Love My Cats": ["ALKP"],
+    "I Love My Dogs": ["ALWP"],
+    "I Love My Horse": ["BMHP"],
+    "I Love My Little Boy": ["BLBP"],
+    "I Love My Little Girl": ["BLGP"],
+    "I Love My Pets": ["AA6P"],
+    "I Love My Pony": ["ALNP"],
+    "IE GO CS: Thunderflash": ["ARAP"],
+    "IE GO CS: Wildfire": ["ANPP"],
+    "IE3: Bomb Blast": ["AXBP", "AXBZ"],
+    "IE3: Lightning Bolt": ["AXSP", "AXSZ"],
+    "IE3: Team Ogre Attacks!": ["AXGP", "AXGZ"],
+    "Ice Age™ 4": ["AQLP"],
+    "Ice Age™": ["AQLE"],
+    "Il professor Layton e la...": ["AKKI"],
+    "Il professor Layton e l’eredità...": ["AL6I"],
+    "Imagine Champion Rider 3D": ["AHSP"],
+    "Imagine® Collection": ["BCLP"],
+    "Imagine® babyz®": ["ABAE"],
+    "Imagine™ Babies 3D": ["ABAP"],
+    "Inazuma Eleven GO Light": ["AE4P"],
+    "Inazuma Eleven GO Shadow": ["AEDP"],
+    "IslandDays": ["BDZJ"],
+    "JAWS: Ultimate Predator": ["AJWE"],
+    "JS-Girl Doki Doki Model…": ["BJSJ"],
+    "Jack the Ripper": ["AAJP"],
+    "Jake Hunter": ["BG9E"],
+    "James Noir's Hollywood Crimes": ["AHCE", "AHCP"],
+    "Jet Dog": ["AJTP"],
+    "Jewel Link Atlantis": ["AJ5P"],
+    "Jewel Link Double Pack": ["BJLP"],
+    "Jewel Master Atlantis 3D": ["AJ5X"],
+    "Jewel Match 3": ["AJUP"],
+    "Jewel Quest Heritage": ["AJ4P"],
+    "JewelPet 3DS": ["AJPJ"],
+    "JewelQuest 6": ["AJ6P"],
+    "Jewelpet 3DS 2": ["AJYJ"],
+    "Jewelpet 3DS 6": ["BJPJ"],
+    "Junior Classic Games": ["AJCE"],
+    "Junior Games 3D": ["AJCP"],
+    "Jレジェンド列伝": ["BNGJ"],
+    "KAWAII KONEKO 3D": ["AKCJ"],
+    "KINGDOM HEARTS 3D": ["AKHE", "AKHJ", "AKHP"],
+    "KOBITO GAME TAIZEN": ["BK3J"],
+    "KOKUGA": ["AK8J"],
+    "KONEKO NO ALBUM": ["BLCJ"],
+    "Kamiwazawanda": ["AWFJ"],
+    "Kankenshogakusei": ["A3KJ"],
+    "Karous": ["BKEJ"],
+    "KasekiHorider MugenGear": ["AHRJ"],
+    "Katsuma Unleashed": ["ADME", "ADMP"],
+    "KenkaBancho6 soul&blood": ["BC6J"],
+    "Kid Icarus: Uprising": ["AKDE", "AKDJ", "AKDP"],
+    "Kirby Battle Royale": ["AJ8E", "AJ8J", "AJ8P"],
+    "Kirby's Extra Epic Yarn": ["BE4E", "BE4J", "BE4P"],
+    "Kirby: Planet Robobot": ["AT3A", "AT3A", "AT3A", "AT3K"],
+    "Kirby: Triple Deluxe": ["BALE", "BALJ", "BALK", "BALP"],
+    "Konchu monster super battle": ["BUXJ"],
+    "Kumamon★Bomber": ["BKMJ"],
+    "Kung Fu Panda:  SLL": ["BKFE"],
+    "Kung Fu Panda: SLL": ["BKFP"],
+    "Kunio-kun nekketsu complete": ["BKCJ"],
+    "Kuniokun SP Ranto Kyosokyoku": ["AK2J", "AK2K"],
+    "Kuniokun Special": ["AK9K"],
+    "LAYTON'S MYSTERY JOURNEY": ["BLFJ"],
+    "LAYTON'S MYSTERY JOURNEY™": ["BLFE", "BLFP"],
+    "LEGO® Batman™ 2": ["ALBD", "ALBE", "ALBF", "ALBP"],
+    "LEGO® Batman™ 3": ["BTME", "BTMJ", "BTMP", "BTMV", "BTMX", "BTMY", "BTMZ"],
+    "LEGO® Chima™": ["APRE", "APRP"],
+    "LEGO® Friends": ["AZJE", "AZJP"],
+    "LEGO® Harry Potter™": ["AHPE", "AHPP"],
+    "LEGO® Jurassic World": ["BLJJ"],
+    "LEGO® Jurassic World™": ["BLJE", "BLJP", "BLJV", "BLJX", "BLJY", "BLJZ"],
+    "LEGO® LotR": ["ALAD", "ALAE", "ALAF", "ALAP", "ALAS"],
+    "LEGO® MARVEL's Avengers": ["ALEE", "ALEJ", "ALEP", "ALEV", "ALEX", "ALEY", "ALEZ"],
+    "LEGO® Marvel™": ["AL5D", "AL5E", "AL5F", "AL5J", "AL5P", "AL5S", "AL5Y"],
+    "LEGO® Movie": ["AFJD", "AFJE", "AFJF", "AFJJ", "AFJP", "AFJS"],
+    "LEGO® Ninjago™": ["BLNE", "BLNJ", "BLNP", "BLNX", "BLNY", "BLNZ", "BLSE", "BLSJ", "BLSP", "BLSX", "BLSY", "BLSZ"],
+    "LEGO® Pirates": ["APCE", "APCP"],
+    "LEGO® STAR WARS™: TFA": ["BLWD", "BLWE", "BLWF", "BLWI", "BLWJ", "BLWP", "BLWS"],
+    "LEGO® The Hobbit™": ["BLHE", "BLHP", "BLHX", "BLHY", "BLHZ"],
+    "La Corda d'Oro3": ["BC3J"],
+    "Lalaloopsy™: CoF": ["ALYE"],
+    "Langrisser -TENSEI-": ["BRGE"],
+    "Legend of Legacy": ["BLLJ"],
+    "Life with Horses 3D": ["BMGP"],
+    "Little Battlers eXperience": ["ADNE", "ADNP", "ADNZ"],
+    "Lord of Magna: Maiden Heaven": ["BKKE"],
+    "Lucky Luke & The Daltons": ["ALJP"],
+    "Luigi's Mansion 2": ["AGGP", "AGGW"],
+    "Luigi's Mansion: Dark Moon": ["AGGE"],
+    "Luigi's Mansion": ["BGNE", "BGNJ", "BGNP"],
+    "Luv Me Buddies Wonderland": ["BWLP"],
+    "Luxor": ["ALXP"],
+    "L’ERA GLACIALE™ 4": ["AQLI"],
+    "M & S London 2012": ["ACME", "ACMK", "ACMP"],
+    "MAHJONG CUB3D": ["ASHE"],
+    "MAJIN BONE": ["BZRJ"],
+    "MARIO KART 7": ["AMKE", "AMKK", "AMKP", "AMKW"],
+    "MCOG: Secret Paths": ["BMCP"],
+    "MEDAROT7 KABUTO": ["AQBJ"],
+    "MEDAROT7 KUWAGATA": ["AQWJ"],
+    "MEDAROT8 KABUTO": ["BMKJ"],
+    "MEDAROT8 KUWAGATA": ["BMQJ"],
+    "MEDAROT9 KABUTO": ["BA9J"],
+    "MEDAROT9 KUWAGATA": ["BB9J"],
+    "METALMAX4": ["AX4J"],
+    "MGS SNAKE EATER 3D": ["AMGE", "AMGJ", "AMGP"],
+    "MH3U": ["AMHE", "AMHP"],
+    "MHSKRM": ["AH5E", "AH5P"],
+    "MIKE THE KNIGHT": ["BMJP"],
+    "MOKOMOKO FRIENDS": ["BM5J"],
+    "MONSTER HUNTER 3 (tri-) G": ["AMHJ"],
+    "MONSTER HUNTER 4 ULTIMATE": ["BFGE", "BFGP"],
+    "MONSTER HUNTER 4G": ["BFGJ", "BFGZ"],
+    "MONSTER HUNTER 4": ["AH4J", "AH4K", "AH4Z"],
+    "MONSTER HUNTER GEN": ["BXXE", "BXXP"],
+    "MONSTER HUNTER STORIES": ["AAHE", "AAHJ", "AAHP"],
+    "MONSTER HUNTER XX": ["AGQJ"],
+    "MONSTER HUNTER X": ["BXXJ"],
+    "MYST": ["AM7E", "AM7P"],
+    "Madagascar 3": ["AMCE", "AMCJ", "AMCP"],
+    "Madden NFL Football": ["AMDE", "AMDP"],
+    "Mahjong 3D": ["AMZE", "AMZP"],
+    "Mahjong Mysteries: Athena": ["AM5P"],
+    "Mahjongg Mysteries: Athena": ["AM5Z"],
+    "Majora's Mask 3D": ["AJRE", "AJRJ", "AJRK", "AJRP"],
+    "Maple Story": ["BMPJ", "BMPK"],
+    "Mario & Luigi: Bowser's Inside…": ["A3RE", "A3RJ", "A3RP"],
+    "Mario & Luigi: Paper…": ["AYNE", "AYNJ", "AYNP"],
+    "Mario & Luigi: Superstar…": ["BRME", "BRMJ", "BRMP"],
+    "Mario & Luigi": ["AYME", "AYMP"],
+    "Mario & Sonic Rio 2016": ["BGXE", "BGXJ", "BGXP"],
+    "Mario Golf: World Tour": ["AJ3E", "AJ3J", "AJ3P"],
+    "Mario Party: Island Tour": ["ATSE", "ATSJ", "ATSP"],
+    "Mario Party: Star Rush": ["BAAE", "BAAJ", "BAAP"],
+    "Mario Party: The Top 100": ["BHRE", "BHRJ", "BHRP"],
+    "Mario Sports Superstars": ["AUNE", "AUNJ", "AUNP"],
+    "Mario Tennis Open": ["AGAE", "AGAJ", "AGAP", "AGAW"],
+    "Mario vs. Donkey Kong: Tippin...": ["JYLJ"],
+    "Mario&Luigi RPG4": ["AYMJ"],
+    "Marvel Super Hero Squad": ["AMSE", "AMSP"],
+    "Me & My Pets 3D": ["BM3P"],
+    "Me & My furry Patients 3D": ["BMTP"],
+    "Medarot DUAL KABUTO Ver.": ["AQVJ"],
+    "Medarot DUAL KUWAGATA Ver.": ["AQAJ"],
+    "Medarot GM KBT Ver.": ["BGPJ"],
+    "Medarot GM KWG Ver.": ["BGQJ"],
+    "Mega Man Legacy Collection": ["BMME", "BMMJ"],
+    "Mensa Academy": ["AMMP"],
+    "Metroid: Samus Returns": ["A9AE", "A9AJ", "A9AP"],
+    "Michael Jackson": ["AMJE", "AMJP"],
+    "Miitopia": ["ADQE", "ADQJ", "ADQP"],
+    "Milton & Friends 3D": ["AM3P"],
+    "Mirror of Fate": ["ACFE", "ACFJ", "ACFP"],
+    "Moco Moco Friends": ["BM5E"],
+    "Mon Royaume Enchanté": ["ADPD"],
+    "Monster 4X4 3D": ["AM4E", "AM4P"],
+    "Monster High NGIS": ["BMSE", "BMSP"],
+    "Monster High™: 13 Wishes": ["AEFP", "AEFZ"],
+    "Monster High™: 13 Wishes™": ["AEFE"],
+    "Moshlings™ Theme Park": ["AA9E", "AA9P"],
+    "Movie Player": ["AABP"],
+    "Murder on the Titanic": ["AM8P"],
+    "Mushibugyo": ["BMBJ"],
+    "My Baby Pet Hotel 3D": ["AEYP"],
+    "My Exotic Farm": ["ABUP"],
+    "My Farm 3D": ["ANJP"],
+    "My Foal 3D": ["AM3Z"],
+    "My Life on a farm 3D": ["BHFP"],
+    "My Little Baby 3D": ["AYYP"],
+    "My Melody": ["BM7J"],
+    "My Pet Puppy 3D": ["AMYE", "APYJ"],
+    "My Pet School 3D": ["BM6P"],
+    "My Vet Practice 3D": ["AERP"],
+    "My Western Horse 3D": ["AZHP"],
+    "NANO ASSAULT": ["AN3J"],
+    "NARUTO 3D": ["ANTF", "ANTP"],
+    "NARUTO Powerful Shippuden": ["AN4E", "AN4P"],
+    "NASCAR® Unleashed": ["AC9E"],
+    "NCIS™ 3D": ["ANCE", "ANCP"],
+    "NEWラブプラス": ["ALPJ"],
+    "NEWラブプラス＋": ["BLPJ"],
+    "Nano Assault": ["AN3E"],
+    "Navy Commander": ["BNCP"],
+    "Need For Speed™ The Run": ["ANSE", "ANSJ", "ANSP"],
+    "Nekketsu Monogatari Special": ["BDJJ"],
+    "New Art Academy": ["AACJ", "AACP"],
+    "New Atelier Rorona": ["BRAJ"],
+    "New SUPER MARIO BROS. 2": ["ABEJ", "ABEP", "ABEW"],
+    "New Style Boutique 2": ["ECDP"],
+    "New Style Boutique 3": ["AJBP"],
+    "New Style Boutique": ["ACLP"],
+    "New Super Mario Bros. 2": ["ABEE"],
+    "Nicktoons MLB® 3D": ["ANKE"],
+    "Nikoli's Pencil Puzzle": ["AS9E", "AS9J"],
+    "Nintendo 3DS Guide: Louvre": ["AL8D", "AL8F", "AL8I", "AL8J", "AL8K", "AL8P", "AL8S"],
+    "Nobunaga's Ambition 2": ["BNYJ"],
+    "Nobunaga's Ambition": ["BNBJ"],
+    "ONE PIECE ROMANCE DAWN": ["BRDP", "BRDZ"],
+    "ONE PIECE UNLIMITEDWORLD R": ["BUWJ"],
+    "ONE PIECE Unlimited World Red": ["BUWE", "BUWP"],
+    "ONE PIECE 大海賊闘技場": ["BUZJ"],
+    "OSYARENA KOINU 3D": ["AYUJ"],
+    "Ocarina of Time 3D": ["AQEE", "AQEJ", "AQEK", "AQEP", "AQEW"],
+    "Ocha-Ken To Itsumo Nakayoshi": ["AE3J"],
+    "One Piece Unlimited Cruise SP 2": ["AL9P"],
+    "One Piece Unlimited Cruise SP": ["ALFP"],
+    "Order Up!!": ["AUPP"],
+    "Oregon Trail": ["AT9E"],
+    "Oshaberi Usagi": ["AUGJ"],
+    "OutbackPetRescue": ["BM4P"],
+    "Outdoors Africa 3D": ["AFKP"],
+    "Oxford Reading Tree vol.1": ["AFZJ"],
+    "Oxford Reading Tree vol.2": ["AX2J"],
+    "Oxford Reading Tree vol.3": ["AX3J"],
+    "P&D CROSS DRAGON type": ["BPVJ"],
+    "P&D CROSS GOD type": ["BPWJ"],
+    "PAC-MAN GHOSTLY ADV 2": ["BPME", "BPMJ", "BPMP"],
+    "PAC-MAN PARTY 3D": ["AP9E", "AP9J", "AP9P"],
+    "PAC-MAN™ GHOSTLY ADV": ["AEJE", "AEJJ", "AEJP"],
+    "PAD SUPER MARIO BROS. ED.": ["AZMJ"],
+    "PAPER MARIO": ["AG5E", "AG5J", "AG5K", "AG5P", "AG5W"],
+    "PERSONAQ2": ["AQ2J"],
+    "PERSONAQ": ["AQQJ"],
+    "PES 2011 3D": ["AEEI", "AEEP"],
+    "PES 2012 3D": ["AE2D", "AE2I", "AE2P"],
+    "PES 2013 3D": ["AWTD", "AWTI", "AWTP"],
+    "POMPOMPURIN": ["BP6J"],
+    "POYOPOYO": ["AP4J"],
+    "PROFESSIONAL BASEBALL SPIRITS 2011": ["APSJ"],
+    "PROJECT CROSS ZONE 2 ": ["BX2K"],
+    "PROJECT X ZONE 2 OGSE": ["BXPJ"],
+    "PROJECT X ZONE 2": ["BX2E", "BX2J", "BX2P"],
+    "PROJECT X ZONE": ["AXXJ"],
+    "PRSMF": ["BSSE", "BSSP"],
+    "PUZZLE BOBBLE UNIVERSE": ["ABBP"],
+    "PW:AA - Spirit of Justice": ["BG6J"],
+    "Pac-Man & Galaga Dimensions": ["APGE", "APGJ", "APGP"],
+    "Paddington: Adv. in London": ["BPLE", "BPLP"],
+    "Paws & Claws Pampered Pets": ["AP8E"],
+    "Pazuru": ["BPZP"],
+    "Peanuts® Movie": ["BPEE", "BPEP"],
+    "Penguins": ["BPGE", "BPGP"],
+    "Persona Q2": ["AQ2E", "AQ2P"],
+    "Persona Q": ["AQQE", "AQQP"],
+    "PersonaQ": ["AQQK"],
+    "Pet Zombies": ["APZE"],
+    "Pets Resort 3D": ["AP3P"],
+    "Petz Fantasy 3D": ["APFE", "APFP"],
+    "Petz® Beach": ["APIE", "APIP"],
+    "Petz® Countryside": ["APOE", "APOP"],
+    "Phineas & Ferb": ["AAWE", "AAWP"],
+    "Phonics Fun with Biff, Chip and…": ["AFZP", "AX2P", "AX3P"],
+    "Picross 3D: Round 2": ["BBPP"],
+    "Pilotwings Resort": ["AWAE", "AWAJ", "AWAP"],
+    "Pinball Hall of Fame": ["APBE", "APBP"],
+    "Pippi Longstocking 3D": ["APEP"],
+    "Pokémon Alpha Sapphire": ["ECLA"],
+    "Pokémon Art Academy": ["BPCE", "BPCJ", "BPCP"],
+    "Pokémon Moon": ["BNEA", "BNEA"],
+    "Pokémon Mystery Dungeon": ["APDE", "APDP"],
+    "Pokemon Mystery Dungeon": ["APDJ"],
+    "Pokémon Omega Ruby": ["ECRA"],
+    "Pokémon Rumble Blast": ["ACCE"],
+    "Pokémon Rumble World": ["ECFA", "ECFA"],
+    "Pokémon SMD": ["BPXE", "BPXJ", "BPXP"],
+    "Pokémon Sun": ["BNDA", "BNDA"],
+    "Pokémon Ultra Moon": ["A2BA", "A2BA"],
+    "Pokémon Ultra Sun": ["A2AA", "A2AA"],
+    "Pokémon X": ["EKJA"],
+    "Pokémon Y": ["EK2A"],
+    "Poochy & Yoshi's Woolly World": ["AJNE", "AJNJ", "AJNP"],
+    "Poptropica: Forgotten Islands": ["BPFE"],
+    "Power Rangers Megaforce": ["AZBE", "AZBP"],
+    "Power of Illusion": ["AECE", "AECP", "AECX"],
+    "PriPriChi-chan!! PriPriDecoroom": ["B2CJ"],
+    "Pro Evolution Soccer 2011 3D": ["AEEE"],
+    "Pro Evolution Soccer 2012 3D": ["AE2E"],
+    "Pro Evolution Soccer 2013 3D": ["AWTE"],
+    "Prof. Layton & the Miracle Mask": ["AKKE"],
+    "Prof. Layton - Maske d. Wunder": ["AKKD"],
+    "Prof. Layton - Vermächtnis...": ["AL6D"],
+    "Prof. Layton VS Ace Attorney": ["AVSJ"],
+    "Prof. Layton en de Erfenis...": ["AL6H"],
+    "Prof. Layton en het Masker...": ["AKKH"],
+    "Prof. Layton et le masque...": ["AKKF"],
+    "Prof. Layton et l’héritage...": ["AL6F"],
+    "Prof. Layton vs Phoenix Wrigh...": ["AVSE", "AVSP", "AVSZ"],
+    "Professor Layton and the Mask of Miracle": ["AKKJ"],
+    "Professor Layton: Azran Legacy": ["AL6E", "AL6P"],
+    "Professor Layton: Miracle Mask": ["AKKP"],
+    "Project X Zone": ["AXXE", "AXXP"],
+    "Puppies 3D": ["ACTE"],
+    "Puppies World 3D": ["ACTP"],
+    "Purr Pals Purrfection": ["AP6E", "AP6P"],
+    "Putty Squad": ["AYZE", "AYZP"],
+    "Puyo Chro": ["BPUJ"],
+    "Puyopuyo Tetris": ["BPTJ"],
+    "Puzzle & Dragons": ["AZGE", "AZGP"],
+    "Puzzler Brain Games": ["AAGP"],
+    "Puzzler Mind Gym 3D": ["APUE", "APUP"],
+    "Puzzler World 2012 3D": ["APWE", "APWP"],
+    "Puzzler World 2013": ["AZLE", "AZLP"],
+    "RABBIDS 3D": ["ARBP"],
+    "RABBIDS": ["ARBE"],
+    "RAYMAN ORIGINS": ["ARME", "ARMJ", "ARMP"],
+    "RESIDENT EVIL  MERCENARIES": ["ABME", "ABMP"],
+    "RESIDENT EVIL REVELATIONS": ["ABRE", "ABRP"],
+    "RIDGE RACER 3D": ["ARRE", "ARRJ", "ARRP"],
+    "RISE OF THE GUARDIANS": ["ARGE", "ARGP"],
+    "RPGMaker Fes": ["BRPE", "BRPJ", "BRPP"],
+    "Rabbids Rumble": ["AR5E", "AR5P"],
+    "Rabbids": ["ARBJ"],
+    "Radiant Historia: PC": ["BRBE", "BRBP"],
+    "Ravenhearst": ["AAQP"],
+    "Rayman 3D": ["ARYE", "ARYP"],
+    "Rayman and Rabbids": ["BRRP"],
+    "Real Heroes: FireFighter 3D": ["ARHD", "ARHE", "ARHP"],
+    "Reel Fishing Paradise 3D": ["ARFE"],
+    "ReelFishingParadise3D": ["ARFP"],
+    "Regular Show": ["AEBE", "AEBP"],
+    "Return to PopoloCrois": ["BPPE"],
+    "Return to Ravenhearst": ["AR2P"],
+    "Rhythm Paradise Megamix": ["BPJP"],
+    "Rhythm Thief": ["ARTE", "ARTJ", "ARTP"],
+    "Ridge Racer 3D": ["ARRJ"],
+    "Riding Stables 3D": ["AAPP", "AMUP"],
+    "Riding Star 3D": ["ARSP"],
+    "Rilakkuma": ["BGYJ"],
+    "RiluRiluFairilu MyFirstFairiluMagic": ["AR8J"],
+    "River City: RIVAL SHOWDOWN": ["BDJE"],
+    "River City: Tokyo Rumble": ["AK2E"],
+    "Rodea the Sky Soldier": ["AR6E", "AR6J", "AR6K", "AR6P"],
+    "RollerCoaster Tycoon® 3D": ["AC8E", "AC8P"],
+    "Rune Factory 4": ["AR4E"],
+    "RuneFactory4": ["AR4J"],
+    "SAF: Miami": ["ASAP"],
+    "SB: Robotic Revenge": ["ANXE", "ANXP"],
+    "SEGA 3D Archives": ["BFKJ"],
+    "SEGA 3D Classics Collection 2": ["BF3J"],
+    "SEGA 3D Classics Collection": ["AK3E", "AK3J", "AK3P"],
+    "SENRAN KAGURA 2 SHINKU": ["BNUJ", "BNUK"],
+    "SENRAN KAGURA 2": ["BNUE", "BNUP"],
+    "SENRAN KAGURA Burst": ["AVHJ", "AVHP"],
+    "SENRAN KAGURA": ["ABHJ"],
+    "SHIFTING WORLD 白と黒の迷宮": ["ASZJ"],
+    "SHOKUGEKI_NO_SOMA": ["BYDJ"],
+    "SM: AFDT": ["AS7F"],
+    "SM: EOT": ["AS7E", "AS7P"],
+    "SMT IV: Apocalypse": ["BG4E", "BG4P"],
+    "SMT: Devil Survivor Overclocked": ["AMTE", "AMTP"],
+    "SMT: Strange Journey Redux": ["AJ9E", "AJ9P"],
+    "SNACK WORLD TREJARERS": ["BWSJ"],
+    "SONIC GENERATIONS": ["ASNE", "ASNJ", "ASNP"],
+    "SONIC LOST WORLD": ["ARVE", "ARVJ", "ARVP"],
+    "SPEC～干～": ["BSPJ"],
+    "STARFOX64 3D": ["ANRJ", "ANRW"],
+    "STELLA GLOW": ["BS3E", "BS3J", "BS3P"],
+    "STORY OF SEASONS": ["BB3E", "BB3P", "BTSE", "BTSP"],
+    "SUDOKU": ["AS9P"],
+    "SUPER MARIO 3D LAND": ["AREE", "AREJ", "AREK", "AREP", "AREW", "AREZ"],
+    "SUPER MONKEY BALL 3D": ["ASME", "ASMJ", "ASMP"],
+    "SUPER STREET FIGHTER Ⅳ": ["ASSE", "ASSJ", "ASSP"],
+    "SW: Chronicles": ["A66E", "A66P"],
+    "Safari Quest": ["BSQP"],
+    "Sangokushi 2": ["BSJJ"],
+    "Saving Alfea": ["BWCE", "BWCP"],
+    "Sayonara Umihara Kawase": ["AUFJ"],
+    "Schlag den Raab 2": ["AS2D"],
+    "Scribblenauts Unlimited": ["ASLE", "ASLP", "ASLX"],
+    "Scribblenauts Unmasked": ["AD6E", "AD6P"],
+    "Secret Mysteries": ["ASXP"],
+    "Secrets of the Titanic": ["ASEP"],
+    "Sekaiju to Fushigi no Dungeon2": ["BD5J"],
+    "Sekaiju to Fushigi no Dungeon": ["BFDJ"],
+    "Shanghai Mahjong": ["BSMP"],
+    "Shantae and the Pirate's Curse": ["AJAE", "AJAP", "BP8J"],
+    "Sherlock Holmes": ["AHAP"],
+    "Sherlock": ["AHAJ"],
+    "Shifting World": ["ASZE", "ASZP"],
+    "Shin Megami Tensei IV": ["AMXE"],
+    "Shinobi™ 3D": ["ASVJ"],
+    "Shinobi™": ["ASVE", "ASVP"],
+    "Shovel Knight": ["AKSE", "AKSJ", "AKSP"],
+    "Skylanders Giants™": ["AG6E", "AG6P", "AG6X"],
+    "Skylanders SWAP Force™": ["BSFE", "BSFP"],
+    "Skylanders SuperChargers™": ["BL5P"],
+    "Skylanders Trap Team™": ["BS9E", "BS9P"],
+    "Skylanders® SuperChargers": ["BL5E"],
+    "Skylanders": ["ASPE", "ASPJ", "ASPP"],
+    "Sonic Boom: Fire & Ice": ["BS6E", "BS6P"],
+    "Sonic Boom": ["BSYE", "BSYP"],
+    "Sonic Toon: F & I": ["BS6J"],
+    "Sonic Toon": ["BSYJ"],
+    "Sonic Transformed": ["ALLE", "ALLP"],
+    "Spirit Camera": ["ALCE", "ALCP"],
+    "SpongeBob HeroPants": ["BPNE", "BPNP"],
+    "SpongeBob SquigglePants": ["ASGE", "ASGP"],
+    "Sports Island 3D": ["ADEP"],
+    "Spot The Differences!": ["BDFP"],
+    "Spy Hunter™": ["AHEE", "AHEP"],
+    "Star Fox 64 3D": ["ANRE", "ANRP"],
+    "Starry☆Sky 3D...": ["AAXJ", "AX6J", "AX7J", "AZPJ"],
+    "Steel Diver": ["ASDE", "ASDJ", "ASDP"],
+    "Sternenschweif 3D": ["BSCD"],
+    "Style Savvy: Fashion Forward": ["ECDE"],
+    "Style Savvy: Trendsetters": ["ACLE"],
+    "Sudoku + 7 other Complex Pu...": ["ANQP"],
+    "Sudoku by NIKOLI 3D vol.2": ["AZNJ"],
+    "Sudoku by NIKOLI 3D": ["ANQJ"],
+    "Suichara the Sweets School": ["B2SJ"],
+    "Super Black Bass 3D": ["ASBE", "ASBP"],
+    "Super Mario Maker": ["AJHE", "AJHJ", "AJHP"],
+    "Super Pokémon Rumble": ["ACCJ", "ACCP"],
+    "Super Smash Bros.": ["AXCE", "AXCJ", "AXCK", "AXCP"],
+    "Survivor 3D": ["AV2P"],
+    "Survivors": ["BSHP"],
+    "Sushi Striker": ["AFWE", "AFWJ", "AFWP"],
+    "TALES OF THE ABYSS": ["AABE", "AABJ", "AABP"],
+    "TEKKEN® 3D PRIME EDITION": ["ATKE", "ATKJ"],
+    "TEKKEN™ 3D PRIME EDITION": ["ATKK", "ATKP"],
+    "TENKAI KNIGHTS™": ["BTKE", "BTKP"],
+    "TERRAFORMARS": ["BFMJ"],
+    "TETRIS®": ["ATLJ"],
+    "TFF CURTAIN CALL": ["BTHE", "BTHP"],
+    "THE CROODS": ["AQRE", "AQRP"],
+    "THE MAHJONG": ["AAUJ"],
+    "THE 密室からの脱出 アーカイブス1": ["BYEJ"],
+    "THE 密室からの脱出 アーカイブス2": ["BP3J"],
+    "THEATRHYTHM FINAL FANTASY": ["ATHE", "ATHP"],
+    "THOMAS & FRIENDS": ["BTBP"],
+    "TIME TRAVELERS": ["ATRJ"],
+    "TMNT:DoTO": ["BMUE", "BMUP"],
+    "TMNT™: MSTP": ["BTNE", "BTNP"],
+    "TMNT™": ["ANYE", "ANYP"],
+    "TOEIC®テスト超速トレーニング": ["ATEJ"],
+    "TORIKO GOURMEGABATTLE!": ["BT5J"],
+    "TOW レーヴ ユナイティア": ["ATUJ"],
+    "TRANSFORMERS 3": ["ATFP"],
+    "TRANSFORMERS PRIME": ["ATPE", "ATPP"],
+    "TRANSFORMERS": ["AYEE", "AYEP"],
+    "TURBO": ["AANE", "AANP"],
+    "Teddy Together": ["AKMP"],
+    "Teenage Mutant Ninja Turtles™": ["BNTE", "BTWP"],
+    "Terraria": ["BTEE", "BTEJ", "BTEP"],
+    "Tetris® Axis": ["ATLE"],
+    "Tetris® Ultimate": ["BTLE", "BTLP"],
+    "Tetris®": ["ATLP"],
+    "The 7th Gate": ["AJQP"],
+    "The Adventures of Tintin": ["ATNE", "ATNJ", "ATNP"],
+    "The Alliance Alive": ["AL4E"],
+    "The Amazing Spider-Man": ["AS8D", "AS8E", "AS8P"],
+    "The Cake Shop 2.": ["AWCJ"],
+    "The Chase Begins": ["AA8E", "AA8J", "AA8P"],
+    "The Clone Wars™": ["ALGE", "ALGP"],
+    "The Cube": ["ACZP"],
+    "The Hidden": ["AHDE"],
+    "The Job's Themepark 2.": ["AWKJ"],
+    "The Legend of Korra™: A New...": ["BLDE"],
+    "The Legend of Legacy": ["BLLE", "BLLP"],
+    "The Legend of Zelda": ["BZLE", "BZLJ", "BZLK", "BZLP"],
+    "The Sims™ 3 Pets": ["AS4E", "AS4J", "AS4P"],
+    "The Sims™ 3": ["AS3E", "AS3J", "AS3P"],
+    "The Trash Pack": ["ATZE", "ATZP"],
+    "The prince of tennis": ["BTPJ"],
+    "Thor": ["AGTE", "AGTP"],
+    "Titanic": ["AASP"],
+    "Tom Clancy's Splinter Cell 3D": ["ASCJ", "ASCP", "ASCZ"],
+    "Tomodachi Life": ["EC6E", "EC6K", "EC6P"],
+    "Tongariboshi To Maho no Machi": ["AVCJ"],
+    "Top Model 3D": ["BT2P"],
+    "Top Trumps NBA": ["AN8E"],
+    "Toriko  Ultimate Survival.": ["BTCJ"],
+    "Touch!DoublePenSports": ["APPJ"],
+    "Transformers™ 3": ["ATFE"],
+    "Tri Force Heroes": ["EA3E", "EA3J", "EA3P", "EA3Z"],
+    "ULTIMATE NES REMIX": ["BFRP"],
+    "Ultimate Bass Fishing 3D": ["AFDJ", "AFDP"],
+    "Ultimate NES Remix": ["BFRE", "BFRJ"],
+    "Ultra baseball Action card battle": ["BUBJ"],
+    "VanguardG STV": ["BCFJ"],
+    "Viking Invasion 2": ["AVKP"],
+    "Virtue's Last Reward": ["AKGP"],
+    "VitaminX Evolution Plus": ["BVXJ"],
+    "VitaminZ Revolution": ["BVZJ"],
+    "WRC The Official Game": ["BWRP"],
+    "WWE All Stars": ["AWEE", "AWEP"],
+    "WarioWare Gold": ["AWXA", "AWXA"],
+    "Wild West 3D": ["AW2E", "AW2P"],
+    "Winning Eleven 2012": ["AE2J"],
+    "Winning Eleven 2013": ["AWTJ"],
+    "Winning Eleven 2014 JE": ["BSBJ"],
+    "Winning Eleven 2014": ["BW4J"],
+    "Winning Eleven 3DSoccer": ["AEEJ"],
+    "Winter Sports 2012": ["AWSP"],
+    "Wipeout 2": ["AWPE"],
+    "Wipeout 3": ["AW3E"],
+    "Wipeout Create & Crash": ["AY8E"],
+    "Word Wizard": ["AWWP"],
+    "YO-KAI SANGOKUSHI": ["AYKJ"],
+    "YO-KAI WATCH 2: BONY …": ["BYGP"],
+    "YO-KAI WATCH 2: FLESHY …": ["BYHP"],
+    "YO-KAI WATCH 2: PSYCHIC …": ["BYSE", "BYSP", "BYSZ"],
+    "YO-KAI WATCH B2: MAGNUM": ["BYMJ"],
+    "YO-KAI WATCH B2: SWORD": ["BYNJ"],
+    "YO-KAI WATCH BLASTERS RD …": ["BYAE", "BYAP"],
+    "YO-KAI WATCH BLASTERS WH…": ["BYBE", "BYBP"],
+    "YO-KAI WATCH": ["AYWE", "AYWK", "AYWP", "AYWZ"],
+    "YOSHI'S New ISLAND": ["ATAE", "ATAJ", "ATAP", "ATAZ"],
+    "Yakari": ["AYRP"],
+    "Yo-kai Watch 2 Bony Spirits": ["BYGE", "BYGZ"],
+    "Yo-kai Watch 2 Fleshy Souls": ["BYHE", "BYHZ"],
+    "Yo-kai Watch 3": ["ALZD", "ALZE", "ALZF", "ALZI", "ALZP", "ALZS"],
+    "Yokai Watch 2 ganso": ["BYGJ"],
+    "Yokai Watch 2 honke": ["BYHJ"],
+    "Yokai Watch 2 shinuchi": ["BYSJ"],
+    "Yokai Watch 3 SUKIYAKI": ["ALZJ"],
+    "Yokai Watch 3 SUSHI": ["BY3J"],
+    "Yokai Watch 3 TEMPURA": ["BY4J"],
+    "Yokai Watch Busters Aka": ["BYAJ"],
+    "Yokai Watch Busters Shiro": ["BYBJ"],
+    "Yokai Watch": ["AYWJ"],
+    "Young Justice™: Legacy": ["AYJE"],
+    "Yu-Gi-Oh! ZEXAL": ["AYXP"],
+    "Yu-Gi-Oh!ZEXAL": ["AYXJ"],
+    "ZE: Virtue's Last Reward": ["AKGE"],
+    "ZERO ESCAPE": ["BZGJ"],
+    "ZETSUBO YOSAI": ["AZUJ"],
+    "ZOO MANIA": ["ANMJ"],
+    "ZOO RESORT": ["AZOE", "AZOP"],
+    "Zero Escape": ["BZEE"],
+    "ZooVetPractice 3D": ["ATXP"],
+    "aikatsu!my two princesses": ["BAKJ"],
+    "atelier deco la doll": ["AULJ"],
+    "attack on titan 2 future": ["AKPJ"],
+    "attack on titan chain": ["BG2J"],
+    "attack on titan": ["BGAJ"],
+    "beybladeburstgod": ["BVBJ"],
+    "beybladeburst": ["BUTJ"],
+    "cooking mama 4:Kitchen Magic": ["ACQE"],
+    "cooking mama 4": ["ACQP"],
+    "doodle jump adventures": ["AEGE", "AEGP", "AEGZ"],
+    "hoppechan minnade…": ["BH2J"],
+    "hoppechan punitto…": ["BH3J"],
+    "hoppechan tukutte!…": ["BHPJ"],
+    "kekiyasan monogatari…": ["BC8J"],
+    "kinkinomaguna": ["BKKJ"],
+    "kouenji joshi soccer 3": ["BKJJ"],
+    "kuniokun special": ["AK9J"],
+    "minna no ennichi": ["AENJ"],
+    "nicopuchi": ["BNPJ"],
+    "nintendogs + cats": ["ADAE", "ADAJ", "ADAJ", "ADAP", "ADAW", "ADBE", "ADBJ", "ADBP", "ADBW", "ADCE", "ADCJ", "ADCP", "ADCW"],
+    "pikapika nurse story2": ["ANAJ"],
+    "pikapikanasumonogatari…": ["AG4J"],
+    "sumikkogurasi": ["AWHJ", "BCNJ"],
+    "sumikkogurasi･･･": ["BSVJ", "BVSJ"],
+    "the Smurfs™": ["BUSE", "BUSP"],
+    "wan-nyan hospital2": ["AWNJ"],
+    "wannyan petshop": ["BWNJ"],
+    "wannyandoubutsubyouin…": ["AWJJ", "BW2J"],
+    "熟語 速引辞典": ["AJXJ"],
+    "雷子": ["BRSJ"],
+    "薄桜鬼 3D": ["AH9J"],
+    "ぼく管 新千歳 with ＪＡＬ": ["BBKJ"],
+    "ナルト 疾風伝 最強忍界決戦！！": ["ANTJ"],
+    "謎惑館 音の間に間に": ["ANWJ"],
+    "トリコ グルメモンスターズ！": ["AT6J"],
+    "鉄たび きかんしゃトーマス編": ["BTGJ"],
+    "ｺﾞﾝ ﾊﾞｸﾊﾞｸﾊﾞｸﾊﾞｸｱﾄﾞﾍﾞﾝﾁｬｰ": ["AG7J"],
+    "マリオ&ソニック ロンドン": ["ACMJ"],
+    "ナナミEnglish上達のコツ": ["AYVJ"],
+    "藤子・F・不二雄キャラクターズ…": ["BFPJ"],
+    "逃走中": ["ATCJ"],
+    "戦闘中": ["BCBJ"],
+    "三國志": ["BGKJ"],
+    "戦国無双 Chronicle ３": ["BC4J"],
+    "魔界王子 devils and realist": ["BDPJ"],
+    "暗殺教室 アサシン育成計画!!": ["BA2J"],
+    "キラメキ わくわくスイーツ": ["BSWJ"],
+    "暗殺教室 殺せんせー大包囲網!!": ["BKLJ"],
+    "まめゴマ はっぴースイーツファーム": ["AGWJ"],
+    "逆転裁判123\u3000成歩堂セレクション": ["BHDJ"],
+    "ドラかず": ["ADWJ"],
+    "まめゴマ": ["AM6J"],
+    "まめしば": ["AMEJ"],
+    "ハマトラ": ["BATJ"],
+    "まほコレ": ["BM8J"],
+    "ソニプロ": ["BS2J"],
+    "闘神都市": ["BTTJ"],
+    "大逆転裁判 -成歩堂龍ノ介の冒險-": ["BDGJ"],
+    "ワンピース ROMANCE DAWN...": ["BRDJ"],
+    "ファミスタ リターンズ": ["BP5J"],
+    "メダロット クラシックス カブト": ["BKUJ"],
+    "メダロット クラシックス クワガタ": ["BKWJ"],
+    "ドラえもん のび太の宝島": ["BNLJ"],
+    "リズム天国 ザ・ベスト＋": ["BPJJ"],
+    "弱虫ペダル 明日への高回転": ["AYPJ"],
+    "ファミスタ クライマックス": ["BYFJ"],
+    "トーマスと あそんでおぼえる...": ["BTFJ"],
+    "ドラえもん のび太と奇跡の島": ["AA2J"],
+    "キラ★メキ おしゃれサロン！": ["AATJ"],
+    "心霊カメラ ～憑いてる手帳～": ["ALCJ"],
+    "太鼓の達人 ちびドラゴンと…": ["ATDJ"],
+    "ドラえもん 南極カチコチ大冒険": ["BDUJ"],
+    "ドラえもん 新・のび太の大魔境": ["BNMJ"],
+    "ワンピース 超グランドバトル！Ｘ": ["BG3J"],
+    "ドラえもん 新・のび太の日本誕生": ["BNNJ"],
+    "ワンピース アンリミテッドクルー…": ["ALFJ"],
+    "太鼓の達人 どんとかつの時空大冒険": ["BT7J"],
+    "太鼓の達人 ドコドン！ミステリー…": ["BT8J"],
+    "ハイキュー!! Cross team match！": ["BHTJ"],
+    "ハイキュー!! 繋げ!頂の景色!!": ["BHQJ"],
+    "アイカツ！365日のアイドルデイズ": ["BA3J"],
+    "洞窟物語３D": ["ACVJ"],
+    "アイカツ！My No.1 Stage!": ["AK4J"],
+    "逆転裁判５": ["AGKJ"],
+    "超・戦闘中": ["AJSJ"],
+    "クマ・トモ": ["AKMJ"],
+    "パズドラＺ": ["AZGJ"],
+    "ご当地鉄道": ["BLTJ"],
+    "ネコ・トモ": ["BNFJ"],
+    "ＴＯＲＥ！": ["BREJ"],
+    "超・逃走中": ["BTUJ"],
+    "シアトリズム FF カーテンコール": ["BTHJ"],
+    "ﾌﾟﾘﾊﾟﾗ めざせ!ｱｲﾄﾞﾙ☆ｸﾞﾗﾝﾌﾟﾘNo.1!": ["APJJ"],
+    "おさわり探偵 小沢里奈 ３": ["AN7J"],
+    "ﾌﾟﾘﾊﾟﾗ めざめよ!女神のﾄﾞﾚｽﾃﾞｻﾞｲﾝ": ["BP7J"],
+    "ハコボーイ！ ハコづめＢＯＸ": ["BC2J"],
+    "仮面ライダー トラベラーズ戦記": ["AXAJ"],
+    "たまごっち！ ドリームスクール": ["BD6J"],
+    "シアトリズム ドラゴンクエスト": ["BTQJ"],
+    "ＮＡＲＵＴＯ ＳＤパワフル疾風伝": ["AN4J", "AN4Z"],
+    "鉄道にっぽん!路線たび ゆいレール編": ["BTYJ"],
+    "かわいい仔犬3D": ["ACTJ"],
+    "ちび☆デビ！": ["AD8J"],
+    "大逆転裁判２": ["AJ2J"],
+    "桃鉄２０１７": ["AKQJ"],
+    "こびとづかん": ["AKVJ", "BK2J"],
+    "ぷよぷよ！！": ["AP2J"],
+    "黒子のバスケ": ["BASJ"],
+    "ベイマックス": ["BH6J"],
+    "なめこリズム": ["BSLJ"],
+    "ダンボール戦機 爆ブースト": ["ADNJ"],
+    "探偵神宮寺三郎 復讐の輪舞": ["AJGJ"],
+    "おうちまいにち たまごっち": ["AQCJ"],
+    "カタチ新発見！ 立体ピクロス２": ["BBPJ"],
+    "瞬足\u3000めざせ！ 全国最強ランナー": ["BSNJ"],
+    "ハイスクールＤ×Ｄ": ["BDDJ"],
+    "ラングリッサー-転生-": ["BRGJ"],
+    "ズーキーパー３D": ["AZKJ"],
+    "ダンボール戦機W 超カスタム": ["BDWJ"],
+    "ちび☆デビ！２": ["ADSJ"],
+    "カルチョビット": ["AHBJ"],
+    "斉木楠雄のΨ難": ["AKAJ"],
+    "善人シボウデス": ["AKGJ"],
+    "マリオカート７": ["AMKJ"],
+    "真・女神転生Ⅳ": ["AMXJ", "AMXZ"],
+    "鉄道にっぽん！": ["ARJJ", "ARKJ"],
+    "世界樹の迷宮Ⅳ": ["ASJJ"],
+    "アベンジャーズ": ["AVNJ"],
+    "探偵神宮寺三郎": ["BG9J"],
+    "ヒーローバンク": ["BHBJ"],
+    "難攻不落三国伝": ["BSDJ"],
+    "デジモンワールド Re:Digitize De…": ["ADJJ"],
+    "トライブクルクル THE G@ME": ["BQRJ"],
+    "ぼくは航空管制官 羽田 ALL STARS": ["BKAJ"],
+    "ぼくは航空管制官 成田 ALL STARS": ["BNAJ"],
+    "ぼくは航空管制官 関空 ALL STARS": ["BPKJ"],
+    "ぼくは航空管制官 那覇 PREMIUM": ["AX5J"],
+    "ぼくは航空管制官 関空 SKY STORY": ["AKXJ"],
+    "ぼくは航空管制官 羽田 with ＪＡＬ": ["AH7J"],
+    "ぼくは航空管制官 成田 with ＡＮＡ": ["AN6J"],
+    "ぼくは航空管制官 ホノルル": ["AHWJ"],
+    "ｱｲﾄﾞﾙﾀｲﾑ ﾌﾟﾘﾊﾟﾗ 夢ｵｰﾙｽﾀｰﾗｲﾌﾞ!": ["B2PJ"],
+    "デビルサバイバー オーバークロック": ["ADVJ"],
+    "デビルサバイバー2ブレイクレコード": ["ADXJ"],
+    "イナズマイレブンGO ダーク": ["AEDJ"],
+    "イナズマイレブンGO シャイン": ["AE4J"],
+    "イナズマイレブンGO ギャラクシー": ["BGSJ", "BGVJ"],
+    "イナズマイレブンGO2 ネップウ": ["ANPJ"],
+    "イナズマイレブンGO2 ライメイ": ["ARAJ"],
+    "クッキングママ４": ["ACQJ"],
+    "ジュエルマスター": ["AJ5J"],
+    "オレ様キングダム": ["AK7J"],
+    "ロストヒーローズ": ["ALHJ"],
+    "ラビリンスの彼方": ["ALVJ"],
+    "ランナバウト３Ｄ": ["ARNJ"],
+    "雷子‐紺碧の章‐": ["ARPJ"],
+    "上海３Ｄキューブ": ["ASHJ"],
+    "漢検トレーニング": ["AXFJ"],
+    "アクリルパレット": ["AYDJ"],
+    "プリズマ☆イリヤ": ["AYLJ"],
+    "星霜のアマゾネス": ["AZSJ"],
+    "クッキングママ５": ["BC5J"],
+    "大東亜興亡史ＤＸ": ["BFEJ"],
+    "ヒーローバンク２": ["BNKJ"],
+    "ロストヒーローズ２ P-EDITION": ["BL3J"],
+    "コープスパーティー ＢＲ": ["BCPJ"],
+    "両目で右脳を鍛える ３Ｄ速読術": ["ASKJ"],
+    "【体験版】パワプロ ヒーローズ": ["AWYJ"],
+    "クレヨンしんちゃん おでんわ～るど": ["BWKJ"],
+    "ｱｲｶﾂｽﾀｰｽﾞ! Myｽﾍﾟｼｬﾙｱﾋﾟｰﾙ": ["AKFJ"],
+    "ぽかぽかアイルー村DX": ["BARJ"],
+    "ウイルスシューターXX": ["AV4J"],
+    "戦国無双クロニクル": ["A66J"],
+    "３Ｄ脳トレーニング": ["AKTJ"],
+    "エクストルーパーズ": ["ALTJ"],
+    "漢検トレーニング２": ["B2KJ"],
+    "ロストヒーローズ２": ["BL2J"],
+    "マギ\u3000新たなる世界": ["BNWJ"],
+    "ファイアーエムブレム if": ["BFXJ", "BFYJ", "BFZJ"],
+    "ラジアントヒストリア ＰＣ": ["BRBJ"],
+    "アンチェインブレイズ レクス": ["AUCJ"],
+    "アンチェインブレイズ エクシヴ": ["AUXJ"],
+    "実況パワフルプロ野球 ヒーローズ": ["BPYJ"],
+    "ガンダムトライエイジSP": ["BTAJ"],
+    "うしみつモンストルオ": ["AG3J"],
+    "ルイージマンション２": ["AGGJ"],
+    "姫ギャル♥パラダイス": ["AHGJ"],
+    "ブロッククラッシュＺ": ["AHZJ"],
+    "マギ\u3000はじまりの迷宮": ["ALMJ"],
+    "スマイルプリキュア！": ["APQJ"],
+    "花といきもの立体図鑑": ["ASUJ"],
+    "モンスターストライク": ["BFLJ"],
+    "ミラクルちゅーんず！": ["BG7J"],
+    "ぐるぐるたまごっち！": ["BGGJ"],
+    "ちゃおイラストクラブ": ["BMDJ"],
+    "ブレイブリーセカンド": ["BSEJ"],
+    "とびだす！パズルボブル3D": ["ABBJ"],
+    "ブレイブリーデフォルトFtS": ["BTRJ"],
+    "牧場物語\u3000ふたごの村＋": ["A22J"],
+    "でんぢゃらすじーさん邪": ["ADZJ"],
+    "ミッキーのふしぎな冒険": ["AECJ"],
+    "ブレイブリーデフォルト": ["AFFJ"],
+    "ＭＯＥＧＥＮＤＡＩ３Ｄ": ["AMAJ"],
+    "創作アリスと王子さま！": ["ARZJ"],
+    "ダンボール戦機ＷＡＲＳ": ["BDNJ"],
+    "僕のヒーローアカデミア": ["BHAJ"],
+    "ポポロクロイス牧場物語": ["BPPJ"],
+    "七つの大罪\u3000真実の冤罪": ["BS7J"],
+    "ﾌﾗｯｼｭ暗算\u3000完全版": ["BSAJ"],
+    "おそ松さん\u3000松まつり！": ["BW3J"],
+    "小林が可愛すぎてツライっ!!": ["BKQJ"],
+    "クレヨンしんちゃん\u3000宇宙DE…": ["ACHJ"],
+    "ドライバー：レネゲイド３D": ["ADRJ"],
+    "牧場物語\u3000はじまりの大地": ["ABQJ"],
+    "ディズニーインフィニティ": ["ADYJ"],
+    "ガールズファッション３Ｄ": ["AGUJ"],
+    "剣と魔法と学園モノ。３Ｄ": ["AKNJ"],
+    "みんなでオートレース３Ｄ": ["ARCJ"],
+    "ライダーレボリューション": ["ARUJ"],
+    "スーパーロボット大戦ＵＸ": ["AS6J"],
+    "パチパラ３Ｄ\u3000大海物語２": ["AU3J"],
+    "ドリームガール\u3000プルミエ": ["BMVJ"],
+    "スーパーロボット大戦ＢＸ": ["BSRJ"],
+    "牧場物語\u3000つながる新天地": ["BTSJ"],
+    "アンパンマンとタッチで…": ["BWTJ"],
+    "イナズマイレブン１・２・３!!": ["AETJ"],
+    "獣電戦隊キョウリュウジャー": ["AAKJ"],
+    "ファイアーエムブレム\u3000覚醒": ["AFEJ"],
+    "大合奏！バンドブラザーズＰ": ["ANEJ"],
+    "おさわり探偵\u3000なめこ大繁殖": ["APMJ"],
+    "真・女神転生Ⅳ\u3000ＦＩＮＡＬ": ["BG4J"],
+    "Ｇｏ！プリンセスプリキュア": ["BG5J"],
+    "かわいいペットとくらそう！": ["BHSJ", "BWAJ"],
+    "プリパラ＆プリティーリズム": ["BPAJ"],
+    "鉄道にっぽん！\u3000会津鉄道編": ["BTXJ"],
+    "黒子のバスケ\u3000未来へのキズナ": ["AK5J"],
+    "レイトン教授と超文明Ａの遺産": ["AL6J"],
+    "ペンギンの問題\u3000ザ・ウォーズ": ["AP5J"],
+    "プリティーリズム・マイ☆デコ": ["APTJ"],
+    "パズドラＺ\u3000限定チャレンジ版": ["APZJ"],
+    "パチパラ３Ｄプレミアム海物語": ["AUMJ"],
+    "戦国無双クロニクル\u3000セカンド": ["AZCJ"],
+    "ドラゴンボールフュージョンズ": ["BDLJ"],
+    "蒼き雷霆\u3000ガンヴォルト\u3000ＳＰ": ["BG8J"],
+    "ハピネスチャージプリキュア！": ["BHCJ"],
+    "トモダチコレクション\u3000新生活": ["EC6J"],
+    "遊んで将棋が強くなる！銀星将棋DX": ["BSGJ"],
+    "びっくり！とびだす！魔法のペン": ["AMPJ"],
+    "パズドラＺ\u3000コロコロ限定体験版": ["ANFJ"],
+    "ねらって！とばして！リラックマ": ["ARLJ"],
+    "パチパラ３Ｄ\u3000デラックス海物語": ["AU9J"],
+    "デジモンＵ\u3000アプリモンスターズ": ["AUDJ"],
+    "ゲームセンターＣＸ３丁目の有野": ["BCXJ"],
+    "ドラゴンボールヒーローズＵＭＸ": ["BD9J"],
+    "ドラゴンボールヒーローズＵＭ２": ["BDBJ"],
+    "ふなっしーの愉快なおはなっしー": ["BFCJ"],
+    "ハローキティとまほうのエプロン": ["BHKJ"],
+    "ドラえもん\u3000のび太の宇宙英雄記": ["BS5J"],
+    "たまごっちのプチプチおみせっち": ["BT4J"],
+    "鉄道にっぽん！\u3000上毛電気鉄道編": ["BTJJ"],
+    "テンカイナイト\u3000ブレイブバトル": ["BTKJ"],
+    "モデル☆おしゃれオーディションＰ": ["AN9J"],
+    "スーパーブラックバス３Ｄファイト": ["ASBJ"],
+    "牧場物語\u3000３つの里の大切な友だち": ["BB3J"],
+    "チョコ犬のちょこっと不思議な物語": ["BCHJ"],
+    "ディズニー\u3000マジックキャッスル２": ["BD2J"],
+    "クレヨンしんちゃん\u3000カスカベ映画": ["BGBJ"],
+    "クッキングママ：スイーツショップ": ["BS8J"],
+    "ビックリマン漢熟覇王三位動乱戦創紀": ["AB9J"],
+    "ドラえもんのび太のひみつ道具博物館": ["AD9J"],
+    "そろばん・あんざん・ﾌﾗｯｼｭ暗算": ["AFUJ"],
+    "怪盗ジョーカー\u3000時を超える怪盗と…": ["AKJJ"],
+    "スライムもりもりドラゴンクエスト３": ["AMRJ"],
+    "モデル☆おしゃれオーディション\u3000２": ["ANLJ"],
+    "忍者じゃじゃ丸くん\u3000さくら姫と火…": ["ANNJ"],
+    "オシャレでかわいい子犬と遊ぼ！海編": ["APIJ"],
+    "オシャレでかわいい子犬と遊ぼ！街編": ["APOJ"],
+    "ものすごく脳を鍛える５分間の鬼トレ": ["ASRJ"],
+    "ちょ～りっち！たまごっちのプチプ…": ["AT5J"],
+    "たまごっちのドキドキ☆ドリームお…": ["AT8J"],
+    "シアトリズムファイナルファンタジー": ["ATHJ"],
+    "鉄道にっぽん！路線たび\u3000近江鉄道編": ["ATJJ"],
+    "パチパラ３Ｄ\u3000大海２アグネス・ラム": ["AU2J"],
+    "女の子と密室にいたら○○しちゃう…": ["AWMJ"],
+    "モデル☆おしゃれオーディションＤＧ": ["AYCJ"],
+    "鉄道にっぽん！路線たび\u3000叡山電車編": ["BEDJ"],
+    "プリティーリズム・レインボーライブ": ["BP2J"]
 }

--- a/data/ids/3ds.json
+++ b/data/ids/3ds.json
@@ -1,14 +1,14 @@
 {
-    "100\uff05 PASUKARU SENSEI\\nPerfect Paint Bombers": [
+    "100\uff05 PASUKARU SENSEI\nPerfect Paint Bombers": [
         "BP4J"
     ],
-    "12 SAI TOROKERU Puzzle\\nFUTARINO Harmony": [
+    "12 SAI TOROKERU Puzzle\nFUTARINO Harmony": [
         "A2PJ"
     ],
-    "12 SAI\\nHONTOU NO KIMOCHI": [
+    "12 SAI\nHONTOU NO KIMOCHI": [
         "BTVJ"
     ],
-    "12 SAI\\nKOISURU Diary": [
+    "12 SAI\nKOISURU Diary": [
         "BA7J"
     ],
     "2in1: Horses 3D, Vol. 2": [
@@ -20,10 +20,10 @@
     "2in1: Horses 3D": [
         "BMFP"
     ],
-    "2in1:LifeHorses3D\\n+BabyPetHotel3D": [
+    "2in1:LifeHorses3D\n+BabyPetHotel3D": [
         "BMXP"
     ],
-    "2in1:VetCountry3D\\n+BabyPetHotel3D": [
+    "2in1:VetCountry3D\n+BabyPetHotel3D": [
         "BELP"
     ],
     "35 Classic Games": [
@@ -65,18 +65,18 @@
     "A-Train 3D": [
         "AALJ"
     ],
-    "ACE COMBAT 3D\\nCROSS RUMBLE": [
+    "ACE COMBAT 3D\nCROSS RUMBLE": [
         "AC3J"
     ],
-    "ACE COMBAT\\nAH LEGACY +": [
+    "ACE COMBAT\nAH LEGACY +": [
         "BCRE",
         "BCRP"
     ],
-    "ACE COMBAT\\nASSAULT HORIZON LEGACY": [
+    "ACE COMBAT\nASSAULT HORIZON LEGACY": [
         "AC3E",
         "AC3P"
     ],
-    "ACECOMBAT 3D\\nCROSSRUMBLE +": [
+    "ACECOMBAT 3D\nCROSSRUMBLE +": [
         "BCRJ"
     ],
     "AIKATSU! Cinderella Lesson": [
@@ -95,14 +95,14 @@
     "AZITO 3D": [
         "AZTJ"
     ],
-    "AZURE STRIKER GUNVOLT:\\nSTRIKER PACK": [
+    "AZURE STRIKER GUNVOLT:\nSTRIKER PACK": [
         "BG8E"
     ],
     "Adventure Time: ETDBIDK": [
         "AY9E",
         "AY9P"
     ],
-    "Adventure Time: The Secret\\nof the Nameless Kingd": [
+    "Adventure Time: The Secret\nof the Nameless Kingd": [
         "AVTE",
         "AVTJ",
         "AVTP"
@@ -116,7 +116,7 @@
     "American Mensa Academy": [
         "AMME"
     ],
-    "Angler's Club\\nUltimate Bass Fishing 3D": [
+    "Angler's Club\nUltimate Bass Fishing 3D": [
         "AFDJ",
         "AFDP"
     ],
@@ -132,7 +132,7 @@
         "EGDJ",
         "EGDK"
     ],
-    "Animal Crossing: New Leaf -\\nWelcome amiibo": [
+    "Animal Crossing: New Leaf -\nWelcome amiibo": [
         "EAAE",
         "EAAJ",
         "EAAP"
@@ -141,7 +141,7 @@
         "EGDE",
         "EGDP"
     ],
-    "Animal Crossing:\\nHappy Home Designer": [
+    "Animal Crossing:\nHappy Home Designer": [
         "EDHE",
         "EDHJ",
         "EDHP"
@@ -149,7 +149,7 @@
     "Animal Hospital": [
         "AZFP"
     ],
-    "Anpanman to asobo\\nnew aiueo kyoushitsu": [
+    "Anpanman to asobo\nnew aiueo kyoushitsu": [
         "AEWJ"
     ],
     "Apollo Justice: Ace Attorney": [
@@ -158,14 +158,14 @@
     "Arcade Classics 3D": [
         "ARDP"
     ],
-    "Are You Smarter Than a\\n5th Grader?": [
+    "Are You Smarter Than a\n5th Grader?": [
         "BY5E"
     ],
-    "Around the World with\\nHello Kitty and Friends": [
+    "Around the World with\nHello Kitty and Friends": [
         "AHKP",
         "AHKZ"
     ],
-    "Art Academy\\nLessons for Everyone!": [
+    "Art Academy\nLessons for Everyone!": [
         "AACE"
     ],
     "Asphalt 3D: Nitro Racing": [
@@ -175,7 +175,7 @@
         "ASFE",
         "ASFP"
     ],
-    "Asterix\\nThe Mansions of the Gods": [
+    "Asterix\nThe Mansions of the Gods": [
         "BMNP"
     ],
     "Atlantic Quest": [
@@ -184,7 +184,7 @@
     "Atooi Collection": [
         "AUTE"
     ],
-    "Attack on Titan\\nEscape from death": [
+    "Attack on Titan\nEscape from death": [
         "AEVJ"
     ],
     "Azada": [
@@ -206,19 +206,19 @@
         "ARXP",
         "BBBJ"
     ],
-    "BIOHAZARD\u00ae\\nREVELATIONS": [
+    "BIOHAZARD\u00ae\nREVELATIONS": [
         "ABRJ",
         "ABRK",
         "ABRW"
     ],
-    "BIOHAZARD\u00ae\\nTHE MERCENARIES 3D": [
+    "BIOHAZARD\u00ae\nTHE MERCENARIES 3D": [
         "ABMJ"
     ],
     "BIT.TRIP SAGA": [
         "ABTE",
         "ABTP"
     ],
-    "BLAZBLUE\\nCONTINUUM SHIFT \u2161": [
+    "BLAZBLUE\nCONTINUUM SHIFT \u2161": [
         "ABLJ",
         "ABLP",
         "ABLZ"
@@ -241,16 +241,16 @@
         "AAVE",
         "AAVP"
     ],
-    "Barbie and Her Sisters\\nPuppy Rescue": [
+    "Barbie and Her Sisters\nPuppy Rescue": [
         "BRQE",
         "BRQP",
         "BRQZ"
     ],
-    "Barbie\u2122\\nGroom and Glam Pups\u2122": [
+    "Barbie\u2122\nGroom and Glam Pups\u2122": [
         "ABYE",
         "ABYP"
     ],
-    "Batman\u2122:\\nArkham Origins Blackgate": [
+    "Batman\u2122:\nArkham Origins Blackgate": [
         "AZEE",
         "AZEP"
     ],
@@ -261,17 +261,17 @@
     "Beautician debut story": [
         "BYCJ"
     ],
-    "Bella Sara 2\\nThe Magic of Drasilmare": [
+    "Bella Sara 2\nThe Magic of Drasilmare": [
         "AY7P"
     ],
-    "Bella Sara\\nThe Magical Horse Adventures": [
+    "Bella Sara\nThe Magical Horse Adventures": [
         "AB2P"
     ],
     "Ben 10\u2122 Galactic Racing": [
         "ABNE",
         "ABNP"
     ],
-    "Best Friends -\\nMy Horse 3D": [
+    "Best Friends -\nMy Horse 3D": [
         "BMEP"
     ],
     "Best of Arcade Games": [
@@ -283,13 +283,13 @@
     "Best of Casual Games": [
         "BCSP"
     ],
-    "Bibi Blocksberg - Das gro\u00dfe\\nHexenbesen-Rennen 2": [
+    "Bibi Blocksberg - Das gro\u00dfe\nHexenbesen-Rennen 2": [
         "AA3D"
     ],
-    "Bibi&Tina\\nDas Spiel zum Kinofilm": [
+    "Bibi&Tina\nDas Spiel zum Kinofilm": [
         "BBTD"
     ],
-    "BonBon Ribbon\\nKiraKiraDance": [
+    "BonBon Ribbon\nKiraKiraDance": [
         "AVRJ"
     ],
     "Boulder Dash\u00ae-XL 3D\u2122": [
@@ -299,7 +299,7 @@
     "Bowling Bonanza 3D": [
         "AB6P"
     ],
-    "Brain Age\\nConcentration Training": [
+    "Brain Age\nConcentration Training": [
         "ASRE"
     ],
     "Brain Training 3D": [
@@ -314,17 +314,17 @@
     "Brunswick Pro Bowling": [
         "ABWE"
     ],
-    "CARDFIGHT!! Vanguard\\nLOCK ON VICTORY!!": [
+    "CARDFIGHT!! Vanguard\nLOCK ON VICTORY!!": [
         "BVGJ"
     ],
-    "CARDFIGHT!! Vanguard\\nRide To Victory!!": [
+    "CARDFIGHT!! Vanguard\nRide To Victory!!": [
         "AVGJ"
     ],
     "CODE OF PRINCESS": [
         "AC7E",
         "AC7J"
     ],
-    "CONCEPTION\u2161\\n\u4e03\u661f\u306e\u5c0e\u304d\u3068\u30de\u30ba\u30eb\u306e\u60aa\u5922": [
+    "CONCEPTION\u2161\n\u4e03\u661f\u306e\u5c0e\u304d\u3068\u30de\u30ba\u30eb\u306e\u60aa\u5922": [
         "BCCJ"
     ],
     "CRASH CITY MAYHEM": [
@@ -350,7 +350,7 @@
         "BZPJ",
         "BZPP"
     ],
-    "Cardfight!! VanguardG\\nSTRIDE TO VICTORY!!": [
+    "Cardfight!! VanguardG\nSTRIDE TO VICTORY!!": [
         "BCFJ"
     ],
     "Carnival Games\u00ae Wild West 3D": [
@@ -368,19 +368,19 @@
         "BRWE",
         "BRWZ"
     ],
-    "Cartoon Network\\nPunch Time Explosion": [
+    "Cartoon Network\nPunch Time Explosion": [
         "ACNE",
         "ACNP"
     ],
     "Cartoonist debut story": [
         "BGHJ"
     ],
-    "Castlevania: Lords of Shadow\\nMirror of Fate": [
+    "Castlevania: Lords of Shadow\nMirror of Fate": [
         "ACFE",
         "ACFJ",
         "ACFP"
     ],
-    "Cats & Dogs\\nPets at play": [
+    "Cats & Dogs\nPets at play": [
         "AHUP"
     ],
     "Cave Story 3D": [
@@ -401,10 +401,10 @@
         "BXLJ",
         "BXLP"
     ],
-    "Classic Games Overload:\\nCard & Puzzle Edition": [
+    "Classic Games Overload:\nCard & Puzzle Edition": [
         "ACGE"
     ],
-    "Cloudy with a Chance\\nof Meatballs 2": [
+    "Cloudy with a Chance\nof Meatballs 2": [
         "AD5E",
         "AD5P",
         "AD5Z"
@@ -415,7 +415,7 @@
     "Code Name: S.T.E.A.M.": [
         "AY6A"
     ],
-    "Combat of Giants:\\nDinosaurs 3D": [
+    "Combat of Giants:\nDinosaurs 3D": [
         "ATTE",
         "ATTJ",
         "ATTP"
@@ -423,7 +423,7 @@
     "Conan\u3000Marionettesymphony": [
         "BKNJ"
     ],
-    "Conception II:\\nChildren of the Seven Stars": [
+    "Conception II:\nChildren of the Seven Stars": [
         "BCCE"
     ],
     "Cooking Mama 5: Bon Appetit!": [
@@ -461,7 +461,7 @@
     "Culdcept": [
         "ACBJ"
     ],
-    "Cut the Rope\u00ae\\nTriple Treat": [
+    "Cut the Rope\u00ae\nTriple Treat": [
         "BR3E",
         "BR3P"
     ],
@@ -470,20 +470,20 @@
         "ADDJ",
         "ADDP"
     ],
-    "DECA SPORTA\\n3D SPORTS": [
+    "DECA SPORTA\n3D SPORTS": [
         "ADEJ"
     ],
     "DECA SPORTS EXTREME": [
         "ADEE"
     ],
-    "DETECTIVE CONAN\\nPHANTOM RHAPSODY": [
+    "DETECTIVE CONAN\nPHANTOM RHAPSODY": [
         "BKRJ"
     ],
-    "DISNEY/PIXAR FINDING NEMO:\\nESCAPE TO THE BIG BLU": [
+    "DISNEY/PIXAR FINDING NEMO:\nESCAPE TO THE BIG BLU": [
         "AF7P",
         "AF7X"
     ],
-    "DISNEY/PIXAR FINDING NEMO\\nESCAPE TO THE BIG BLUE": [
+    "DISNEY/PIXAR FINDING NEMO\nESCAPE TO THE BIG BLUE": [
         "AF7E"
     ],
     "DQM2": [
@@ -502,7 +502,7 @@
         "BDLE",
         "BDLP"
     ],
-    "DRAGON BALL Z:\\nExtreme Butoden": [
+    "DRAGON BALL Z:\nExtreme Butoden": [
         "BDVE",
         "BDVP"
     ],
@@ -526,17 +526,17 @@
     "Devil Summoner: Soul Hackers": [
         "AHQJ"
     ],
-    "Devil Survivor 2:\\nRecord Breaker": [
+    "Devil Survivor 2:\nRecord Breaker": [
         "ADXP"
     ],
-    "Devil Survivor 2\\nRecord Breaker": [
+    "Devil Survivor 2\nRecord Breaker": [
         "ADXE"
     ],
-    "Devilish Brain Training\\nCan you stay focused?": [
+    "Devilish Brain Training\nCan you stay focused?": [
         "ASRP",
         "ASRW"
     ],
-    "Die drei ??? Kids\\nJagd auf das Phantom": [
+    "Die drei ??? Kids\nJagd auf das Phantom": [
         "BD4D"
     ],
     "Dillon's Dead-Heat Breakers": [
@@ -551,12 +551,12 @@
         "BWDJ",
         "BWDP"
     ],
-    "Disney Big Hero 6:\\nBattle in the Bay": [
+    "Disney Big Hero 6:\nBattle in the Bay": [
         "BH6E",
         "BH6P",
         "BH6Z"
     ],
-    "Disney Epic Mickey:\\nPower of Illusion": [
+    "Disney Epic Mickey:\nPower of Illusion": [
         "AECE",
         "AECP",
         "AECX"
@@ -569,17 +569,17 @@
         "AEHJ",
         "AEHP"
     ],
-    "Disney Frozen:\\nOlaf\u2019s Quest": [
+    "Disney Frozen:\nOlaf\u2019s Quest": [
         "AEHZ"
     ],
-    "Disney Infinity:\\nToy Box Challenge": [
+    "Disney Infinity:\nToy Box Challenge": [
         "ADYE"
     ],
     "Disney Infinity": [
         "ADYP",
         "ADYZ"
     ],
-    "Disney Magic Castle\\nMy Happy Life": [
+    "Disney Magic Castle\nMy Happy Life": [
         "AMQJ"
     ],
     "Disney Magical World 2": [
@@ -590,7 +590,7 @@
         "AMQE",
         "AMQP"
     ],
-    "Disney Planes\\nFire & Rescue": [
+    "Disney Planes\nFire & Rescue": [
         "BPRE",
         "BPRP"
     ],
@@ -601,12 +601,12 @@
         "APNY",
         "APNZ"
     ],
-    "Disney Princess\\nMy Fairytale Adventure": [
+    "Disney Princess\nMy Fairytale Adventure": [
         "ADPE",
         "ADPP",
         "ADPX"
     ],
-    "Disney Princesses\\nMon Royaume Enchant\u00e9": [
+    "Disney Princesses\nMon Royaume Enchant\u00e9": [
         "ADPD"
     ],
     "Disney Violetta: Rhythm & Music": [
@@ -616,7 +616,7 @@
         "AWRE",
         "AWRP"
     ],
-    "Doctor Lautrec\\nand the Forgotten Knights": [
+    "Doctor Lautrec\nand the Forgotten Knights": [
         "ADLE",
         "ADLJ",
         "ADLP"
@@ -630,7 +630,7 @@
     "Donkey Kong Returns 3D": [
         "AYTJ"
     ],
-    "Donkey Kong\\nCountry Returns 3D": [
+    "Donkey Kong\nCountry Returns 3D": [
         "AYTE",
         "AYTP"
     ],
@@ -649,7 +649,7 @@
     "Downtown Nekketsu Jidaigeki": [
         "BNJJ"
     ],
-    "Dragon Ball Heroes\\nUltimate Mission": [
+    "Dragon Ball Heroes\nUltimate Mission": [
         "ADGJ"
     ],
     "Dragon Quest VIII": [
@@ -664,7 +664,7 @@
     "DreamWorks Combo Pack": [
         "AGCP"
     ],
-    "DreamWorks\u00ae\\nSuper Star Kartz\u2122": [
+    "DreamWorks\u00ae\nSuper Star Kartz\u2122": [
         "AKZE",
         "AKZP"
     ],
@@ -690,7 +690,7 @@
     "ETRIAN MYSTERY DUNGEON": [
         "BFDE"
     ],
-    "ETRIAN ODYSSEY V:\\nBEYOND THE MYTH": [
+    "ETRIAN ODYSSEY V:\nBEYOND THE MYTH": [
         "BMZP"
     ],
     "EXSTETRA": [
@@ -699,26 +699,26 @@
     "Earthpedia": [
         "AEPJ"
     ],
-    "El profesor Layton\\ny el legado de los ashalanti": [
+    "El profesor Layton\ny el legado de los ashalanti": [
         "AL6S"
     ],
-    "El profesor Layton\\ny la m\u00e1scara de los prodigios": [
+    "El profesor Layton\ny la m\u00e1scara de los prodigios": [
         "AKKS"
     ],
-    "Elminage Gothic 3D REMIX\\n-Ulm Zakiher and Dark R": [
+    "Elminage Gothic 3D REMIX\n-Ulm Zakiher and Dark R": [
         "AEUJ"
     ],
-    "Elminage Ibun\\nAme no Mihashira Kai": [
+    "Elminage Ibun\nAme no Mihashira Kai": [
         "BAMJ"
     ],
     "Etrian Mystery Dungeon": [
         "BFDP"
     ],
-    "Etrian Odyssey 2 Untold:\\nThe Fafnir Knight": [
+    "Etrian Odyssey 2 Untold:\nThe Fafnir Knight": [
         "BM9E",
         "BM9P"
     ],
-    "Etrian Odyssey IV\\nLegends of the Titan": [
+    "Etrian Odyssey IV\nLegends of the Titan": [
         "ASJE",
         "ASJP"
     ],
@@ -726,20 +726,20 @@
         "BZME",
         "BZMP"
     ],
-    "Etrian Odyssey Untold 2\\nKnight of Fafnir": [
+    "Etrian Odyssey Untold 2\nKnight of Fafnir": [
         "BM9J"
     ],
-    "Etrian Odyssey Untold\\nMaiden of Millennium": [
+    "Etrian Odyssey Untold\nMaiden of Millennium": [
         "BSKJ"
     ],
-    "Etrian Odyssey Untold\\nThe Millennium Girl": [
+    "Etrian Odyssey Untold\nThe Millennium Girl": [
         "BSKE",
         "BSKP"
     ],
-    "Etrian Odyssey V:\\nBeyond the Myth": [
+    "Etrian Odyssey V:\nBeyond the Myth": [
         "BMZE"
     ],
-    "Etrian Odyssey V\\nBeyond the Legends": [
+    "Etrian Odyssey V\nBeyond the Legends": [
         "BMZJ"
     ],
     "Etrian Odyssey X": [
@@ -796,7 +796,7 @@
         "BCEE",
         "BCEP"
     ],
-    "FIREMAN SAM\\nTO THE RESCUE!": [
+    "FIREMAN SAM\nTO THE RESCUE!": [
         "AFTP"
     ],
     "FISH ON": [
@@ -835,23 +835,23 @@
         "AFHE",
         "AFHP"
     ],
-    "Fate/kaleid liner\\n\u30d7\u30ea\u30ba\u30de\u2606\u30a4\u30ea\u30e4": [
+    "Fate/kaleid liner\n\u30d7\u30ea\u30ba\u30de\u2606\u30a4\u30ea\u30e4": [
         "AYLJ"
     ],
     "Fire Emblem Awakening": [
         "AFEE"
     ],
-    "Fire Emblem Echoes:\\nShadows of Valentia": [
+    "Fire Emblem Echoes:\nShadows of Valentia": [
         "AJJE",
         "AJJJ",
         "AJJK",
         "AJJP"
     ],
-    "Fire Emblem Fates\\nBirthright": [
+    "Fire Emblem Fates\nBirthright": [
         "BFXE",
         "BFXP"
     ],
-    "Fire Emblem Fates\\nConquest": [
+    "Fire Emblem Fates\nConquest": [
         "BFYE",
         "BFYP"
     ],
@@ -876,7 +876,7 @@
         "AHRD",
         "AHRE"
     ],
-    "Freakyforms Deluxe\\nYour Creations, Alive!": [
+    "Freakyforms Deluxe\nYour Creations, Alive!": [
         "ATQE",
         "ATQP"
     ],
@@ -897,13 +897,13 @@
         "AFMJ",
         "AFMP"
     ],
-    "Future Card Buddyfight\\nHead for BuddyChampion": [
+    "Future Card Buddyfight\nHead for BuddyChampion": [
         "BFAJ"
     ],
-    "Future Card Buddyfight\\nHereComes OurStrongestBud": [
+    "Future Card Buddyfight\nHereComes OurStrongestBud": [
         "BFBJ"
     ],
-    "Future Card Buddyfight\\nfriendship exploding figh": [
+    "Future Card Buddyfight\nfriendship exploding figh": [
         "BDYJ"
     ],
     "G1 Grand Prix": [
@@ -915,7 +915,7 @@
     "GIRLS MODE 3\u3000\u30ad\u30e9\u30ad\u30e9\u2606\u30b3\u30fc\u30c7": [
         "ECDJ"
     ],
-    "GIRLS MODE\\n\u3088\u304f\u3070\u308a\u5ba3\u8a00\uff01\u3000\u30c8\u30ad\u30e1\u30adUP\uff01": [
+    "GIRLS MODE\n\u3088\u304f\u3070\u308a\u5ba3\u8a00\uff01\u3000\u30c8\u30ad\u30e1\u30adUP\uff01": [
         "ACLJ"
     ],
     "GUDETAMA2:": [
@@ -930,7 +930,7 @@
     "GUNDAM THE 3D BATTLE": [
         "A78J"
     ],
-    "GYROZETTER\\nWings of Albaross": [
+    "GYROZETTER\nWings of Albaross": [
         "ABCJ"
     ],
     "Gabrielle's Ghostly Groove 3D": [
@@ -955,13 +955,13 @@
     "Games Festival 2": [
         "AAFP"
     ],
-    "Gardening Mama 2\\nForest Friends": [
+    "Gardening Mama 2\nForest Friends": [
         "BGME"
     ],
-    "Gardening Mama\\nMama and Her Forest Friends": [
+    "Gardening Mama\nMama and Her Forest Friends": [
         "BGMJ"
     ],
-    "Gardening mama\\nForest Friends": [
+    "Gardening mama\nForest Friends": [
         "BGMP"
     ],
     "Gardenscapes": [
@@ -974,11 +974,11 @@
     "Gem Smashers": [
         "AGSE"
     ],
-    "Generator Rex:\\nAgent of Providence": [
+    "Generator Rex:\nAgent of Providence": [
         "AGXE",
         "AGXP"
     ],
-    "Girls Mode 4\\n\u30b9\u30bf\u30fc\u2606\u30b9\u30bf\u30a4\u30ea\u30b9\u30c8": [
+    "Girls Mode 4\n\u30b9\u30bf\u30fc\u2606\u30b9\u30bf\u30a4\u30ea\u30b9\u30c8": [
         "AJBJ"
     ],
     "Girls' Fashion Shoot": [
@@ -997,20 +997,20 @@
         "AGFE",
         "AGFP"
     ],
-    "Green Lantern\u2122\\nRise of the Manhunters": [
+    "Green Lantern\u2122\nRise of the Manhunters": [
         "AGLE",
         "AGLP"
     ],
-    "Gummy Bears\\nMagical Medallion": [
+    "Gummy Bears\nMagical Medallion": [
         "AGVP"
     ],
-    "HATSUNE MIKU\\nProject mirai 2": [
+    "HATSUNE MIKU\nProject mirai 2": [
         "AHNJ"
     ],
-    "HATSUNE MIKU\\nProject mirai": [
+    "HATSUNE MIKU\nProject mirai": [
         "AM9J"
     ],
-    "HEAVY FIRE\\nTHE CHOSEN FEW": [
+    "HEAVY FIRE\nTHE CHOSEN FEW": [
         "AHVJ"
     ],
     "HELLO KITTY 3D RACING": [
@@ -1022,62 +1022,62 @@
         "BZHJ",
         "BZHP"
     ],
-    "Hakuoki:\\nMemories of the Shinsengumi": [
+    "Hakuoki:\nMemories of the Shinsengumi": [
         "AH9P"
     ],
-    "Hakuoki\\n~Memories of the Shinsengumi~": [
+    "Hakuoki\n~Memories of the Shinsengumi~": [
         "AH9E"
     ],
     "Happy Feet 2": [
         "AHFE",
         "AHFP"
     ],
-    "Harvest Moon:\\nA New Beginning": [
+    "Harvest Moon:\nA New Beginning": [
         "ABQE",
         "ABQP"
     ],
-    "Harvest Moon:\\nSkytree Village": [
+    "Harvest Moon:\nSkytree Village": [
         "AVAE",
         "AVAP"
     ],
-    "Harvest Moon:\\nThe Lost Valley": [
+    "Harvest Moon:\nThe Lost Valley": [
         "AVME",
         "AVMP"
     ],
-    "Harvest Moon\\nThe Tale of Two Towns": [
+    "Harvest Moon\nThe Tale of Two Towns": [
         "AT2E",
         "AT2P"
     ],
-    "Hatsune Miku:\\nProject Mirai DX": [
+    "Hatsune Miku:\nProject Mirai DX": [
         "BRXE",
         "BRXP"
     ],
-    "Hatsune Miku\\nProject Mirai DX": [
+    "Hatsune Miku\nProject Mirai DX": [
         "BRXJ"
     ],
-    "Heavy Fire:\\nThe Chosen Few 3D": [
+    "Heavy Fire:\nThe Chosen Few 3D": [
         "AHVP"
     ],
-    "Heavy Fire:\\nThe Chosen Few": [
+    "Heavy Fire:\nThe Chosen Few": [
         "AHVE"
     ],
-    "Hello Kitty & Friends:\\nRockin' World Tour": [
+    "Hello Kitty & Friends:\nRockin' World Tour": [
         "BKTJ",
         "BKTP"
     ],
-    "Hello Kitty & the Apron of Magic\\nRhythm Cooking\u266a": [
+    "Hello Kitty & the Apron of Magic\nRhythm Cooking\u266a": [
         "BHKP"
     ],
-    "Hello Kitty Picnic\\nwith Sanrio Characters": [
+    "Hello Kitty Picnic\nwith Sanrio Characters": [
         "AHLD"
     ],
-    "Hello Kitty Picnic\\nwith Sanrio Friends": [
+    "Hello Kitty Picnic\nwith Sanrio Friends": [
         "AHLE"
     ],
     "Hello Kitty around the World": [
         "AHKJ"
     ],
-    "Hello Kitty\\nHappy Happy Family": [
+    "Hello Kitty\nHappy Happy Family": [
         "BHHP"
     ],
     "Heroes of Ruin": [
@@ -1089,10 +1089,10 @@
         "BRCJ",
         "BRCP"
     ],
-    "Hidden Expedition\\nTitanic": [
+    "Hidden Expedition\nTitanic": [
         "AASP"
     ],
-    "Hollywood Fame:\\nHidden Object Adventure": [
+    "Hollywood Fame:\nHidden Object Adventure": [
         "AFXP"
     ],
     "Hometown Story": [
@@ -1100,7 +1100,7 @@
         "AHXJ",
         "AHXP"
     ],
-    "Horrid Henry: The Good,\\nThe Bad And The Bugly": [
+    "Horrid Henry: The Good,\nThe Bad And The Bugly": [
         "AHHP"
     ],
     "Horse Life 4": [
@@ -1125,7 +1125,7 @@
         "BTDE",
         "BTDP"
     ],
-    "HyakumasuDorazan\\nNobitaNoTimeBattle": [
+    "HyakumasuDorazan\nNobitaNoTimeBattle": [
         "BNHJ"
     ],
     "I Love My Cats": [
@@ -1149,16 +1149,16 @@
     "I Love My Pony": [
         "ALNP"
     ],
-    "Ice Age\u2122 4\\nArctic Games": [
+    "Ice Age\u2122 4\nArctic Games": [
         "AQLP"
     ],
-    "Ice Age\u2122\\nArctic Games": [
+    "Ice Age\u2122\nArctic Games": [
         "AQLE"
     ],
-    "Il professor Layton\\ne la maschera dei miracoli": [
+    "Il professor Layton\ne la maschera dei miracoli": [
         "AKKI"
     ],
-    "Il professor Layton\\ne l\u2019eredit\u00e0 degli Aslant": [
+    "Il professor Layton\ne l\u2019eredit\u00e0 degli Aslant": [
         "AL6I"
     ],
     "Imagine Champion Rider 3D": [
@@ -1167,46 +1167,46 @@
     "Imagine\u00ae Collection": [
         "BCLP"
     ],
-    "Imagine\u00ae\\nbabyz\u00ae": [
+    "Imagine\u00ae\nbabyz\u00ae": [
         "ABAE"
     ],
-    "Imagine\u2122\\nBabies 3D": [
+    "Imagine\u2122\nBabies 3D": [
         "ABAP"
     ],
-    "Imagine\u2122\\nFashion Designer 3D": [
+    "Imagine\u2122\nFashion Designer 3D": [
         "AGUP"
     ],
-    "Imagine\u2122\\nFashion Designer": [
+    "Imagine\u2122\nFashion Designer": [
         "AGUE"
     ],
-    "Imagine\u2122\\nFashion Life": [
+    "Imagine\u2122\nFashion Life": [
         "AF3E"
     ],
-    "Imagine\u2122\\nFashion World 3D": [
+    "Imagine\u2122\nFashion World 3D": [
         "AF3P"
     ],
-    "Inazuma Eleven 3\\nBomb Blast": [
+    "Inazuma Eleven 3\nBomb Blast": [
         "AXBP",
         "AXBZ"
     ],
-    "Inazuma Eleven 3\\nLightning Bolt": [
+    "Inazuma Eleven 3\nLightning Bolt": [
         "AXSP",
         "AXSZ"
     ],
-    "Inazuma Eleven 3\\nTeam Ogre Attacks!": [
+    "Inazuma Eleven 3\nTeam Ogre Attacks!": [
         "AXGP",
         "AXGZ"
     ],
-    "Inazuma Eleven GO\\nChrono Stones: Thunderflash": [
+    "Inazuma Eleven GO\nChrono Stones: Thunderflash": [
         "ARAP"
     ],
-    "Inazuma Eleven GO\\nChrono Stones: Wildfire": [
+    "Inazuma Eleven GO\nChrono Stones: Wildfire": [
         "ANPP"
     ],
-    "Inazuma Eleven GO\\nLight": [
+    "Inazuma Eleven GO\nLight": [
         "AE4P"
     ],
-    "Inazuma Eleven GO\\nShadow": [
+    "Inazuma Eleven GO\nShadow": [
         "AEDP"
     ],
     "IslandDays": [
@@ -1215,36 +1215,36 @@
     "JAWS: Ultimate Predator": [
         "AJWE"
     ],
-    "JS-Girl Doki Doki\\nModel Challenge": [
+    "JS-Girl Doki Doki\nModel Challenge": [
         "BJSJ"
     ],
-    "Jake Hunter\\nGHOST OF THE DUSK": [
+    "Jake Hunter\nGHOST OF THE DUSK": [
         "BG9E"
     ],
     "James Noir's Hollywood Crimes": [
         "AHCE"
     ],
-    "James Noir's\\nHollywood Crimes 3D": [
+    "James Noir's\nHollywood Crimes 3D": [
         "AHCP"
     ],
     "Jet Dog": [
         "AJTP"
     ],
-    "Jewel Link Double Pack\\nAtlantic Quest / Safari Q": [
+    "Jewel Link Double Pack\nAtlantic Quest / Safari Q": [
         "BJLP"
     ],
-    "Jewel Link\\nLegends of Atlantis": [
+    "Jewel Link\nLegends of Atlantis": [
         "AJ5P"
     ],
     "Jewel Master Atlantis 3D": [
         "AJ5X"
     ],
-    "Jewel Master\\nCradle of Egypt 2 3D": [
+    "Jewel Master\nCradle of Egypt 2 3D": [
         "AJEE",
         "AJEF",
         "AJEP"
     ],
-    "Jewel Master\\nCradle of Rome 2": [
+    "Jewel Master\nCradle of Rome 2": [
         "AJLE",
         "AJLP",
         "AJLZ"
@@ -1255,7 +1255,7 @@
     "Jewel Quest Heritage": [
         "AJ4P"
     ],
-    "Jewel Quest Mysteries\\nThe Seventh Gate": [
+    "Jewel Quest Mysteries\nThe Seventh Gate": [
         "AJQP"
     ],
     "JewelPet 3DS": [
@@ -1279,7 +1279,7 @@
     "KAWAII KONEKO 3D": [
         "AKCJ"
     ],
-    "KINGDOM HEARTS 3D\\n[Dream Drop Distance]": [
+    "KINGDOM HEARTS 3D\n[Dream Drop Distance]": [
         "AKHE",
         "AKHJ",
         "AKHP"
@@ -1296,16 +1296,16 @@
     "KaiteoboeruDoragana": [
         "BDAJ"
     ],
-    "Kamiwazawanda\\nKirakiraichibangai Kikiippatsu!": [
+    "Kamiwazawanda\nKirakiraichibangai Kikiippatsu!": [
         "AWFJ"
     ],
-    "Karous\\n- The Beast Of Re\uff1aEden -": [
+    "Karous\n- The Beast Of Re\uff1aEden -": [
         "BKEJ"
     ],
     "KasekiHorider MugenGear": [
         "AHRJ"
     ],
-    "KenkaBancho6\\nsoul&blood": [
+    "KenkaBancho6\nsoul&blood": [
         "BC6J"
     ],
     "Kid Icarus: Uprising": [
@@ -1333,17 +1333,17 @@
         "BALK",
         "BALP"
     ],
-    "Konchu monster\\nsuper battle": [
+    "Konchu monster\nsuper battle": [
         "BUXJ"
     ],
-    "Kumamon\u2605Bomber\\nPuzzle de Kumamontaisou": [
+    "Kumamon\u2605Bomber\nPuzzle de Kumamontaisou": [
         "BKMJ"
     ],
     "Kung Fu Panda: SLL": [
         "BKFE",
         "BKFP"
     ],
-    "Kunio-kun nekketsu complete\\nfamicom edition": [
+    "Kunio-kun nekketsu complete\nfamicom edition": [
         "BKCJ"
     ],
     "Kuniokun SP Ranto Kyosokyoku": [
@@ -1353,20 +1353,20 @@
     "Kuniokun Special": [
         "AK9K"
     ],
-    "LAYTON'S MYSTERY JOURNEY\\nKatrielle and the Milli": [
+    "LAYTON'S MYSTERY JOURNEY\nKatrielle and the Milli": [
         "BLFJ"
     ],
-    "LAYTON'S MYSTERY JOURNEY\u2122\\nKatrielle and the Mill": [
+    "LAYTON'S MYSTERY JOURNEY\u2122\nKatrielle and the Mill": [
         "BLFE",
         "BLFP"
     ],
-    "LEGO\u00ae Batman\u2122 2:\\nDC Super Heroes": [
+    "LEGO\u00ae Batman\u2122 2:\nDC Super Heroes": [
         "ALBD",
         "ALBE",
         "ALBF",
         "ALBP"
     ],
-    "LEGO\u00ae Batman\u2122 3\\nBeyond Gotham": [
+    "LEGO\u00ae Batman\u2122 3\nBeyond Gotham": [
         "BTME",
         "BTMJ",
         "BTMP",
@@ -1375,7 +1375,7 @@
         "BTMY",
         "BTMZ"
     ],
-    "LEGO\u00ae City Undercover:\\nThe Chase Begins": [
+    "LEGO\u00ae City Undercover:\nThe Chase Begins": [
         "AA8E",
         "AA8J",
         "AA8P"
@@ -1384,7 +1384,7 @@
         "AZJE",
         "AZJP"
     ],
-    "LEGO\u00ae Harry Potter\u2122:\\nYears 5-7": [
+    "LEGO\u00ae Harry Potter\u2122:\nYears 5-7": [
         "AHPE",
         "AHPP"
     ],
@@ -1403,7 +1403,7 @@
         "APRE",
         "APRP"
     ],
-    "LEGO\u00ae MARVEL's\\nAvengers": [
+    "LEGO\u00ae MARVEL's\nAvengers": [
         "ALEE",
         "ALEJ",
         "ALEP",
@@ -1412,7 +1412,7 @@
         "ALEY",
         "ALEZ"
     ],
-    "LEGO\u00ae Marvel\u2122 Super Heroes\\nUniverse in Peril": [
+    "LEGO\u00ae Marvel\u2122 Super Heroes\nUniverse in Peril": [
         "AL5D",
         "AL5E",
         "AL5F",
@@ -1421,10 +1421,10 @@
         "AL5S",
         "AL5Y"
     ],
-    "LEGO\u00ae Ninjago\u2122:\\nShadow of Ronin": [
+    "LEGO\u00ae Ninjago\u2122:\nShadow of Ronin": [
         "BLSE"
     ],
-    "LEGO\u00ae Ninjago\u2122\\nNindroids\u2122": [
+    "LEGO\u00ae Ninjago\u2122\nNindroids\u2122": [
         "BLNE",
         "BLNJ",
         "BLNP",
@@ -1432,11 +1432,11 @@
         "BLNY",
         "BLNZ"
     ],
-    "LEGO\u00ae Pirates of the Caribbean\\nThe Video Game": [
+    "LEGO\u00ae Pirates of the Caribbean\nThe Video Game": [
         "APCE",
         "APCP"
     ],
-    "LEGO\u00ae STAR WARS\u2122:\\nThe Force Awakens": [
+    "LEGO\u00ae STAR WARS\u2122:\nThe Force Awakens": [
         "BLWD",
         "BLWE",
         "BLWF",
@@ -1445,10 +1445,10 @@
         "BLWP",
         "BLWS"
     ],
-    "LEGO\u00ae StarWars\u00ae III:\\nThe Clone Wars\u2122": [
+    "LEGO\u00ae StarWars\u00ae III:\nThe Clone Wars\u2122": [
         "ALGE"
     ],
-    "LEGO\u00ae StarWars\u2122 III:\\nThe Clone Wars\u2122": [
+    "LEGO\u00ae StarWars\u2122 III:\nThe Clone Wars\u2122": [
         "ALGP"
     ],
     "LEGO\u00ae The Hobbit\u2122": [
@@ -1465,30 +1465,30 @@
         "ALAP",
         "ALAS"
     ],
-    "LEGO\u00aeNinjago\u2122:\\nShadow of Ronin": [
+    "LEGO\u00aeNinjago\u2122:\nShadow of Ronin": [
         "BLSJ",
         "BLSP",
         "BLSX",
         "BLSY",
         "BLSZ"
     ],
-    "La Corda d'Oro3\\nFullvoice Special": [
+    "La Corda d'Oro3\nFullvoice Special": [
         "BC3J"
     ],
-    "Lalaloopsy\u2122:\\nCarnival of Friends": [
+    "Lalaloopsy\u2122:\nCarnival of Friends": [
         "ALYE"
     ],
-    "Langrisser Re:Incarnation\\n-TENSEI-": [
+    "Langrisser Re:Incarnation\n-TENSEI-": [
         "BRGE"
     ],
     "Legend of Legacy": [
         "BLLJ"
     ],
-    "Legends Of Oz:\\nDorothy's Return": [
+    "Legends Of Oz:\nDorothy's Return": [
         "BDTE",
         "BDTP"
     ],
-    "Let's Ride\\nBest in Breed 3D\u2122": [
+    "Let's Ride\nBest in Breed 3D\u2122": [
         "ALDE"
     ],
     "Life with Horses 3D": [
@@ -1523,15 +1523,15 @@
     "Luxor": [
         "ALXP"
     ],
-    "L\u2019ERA GLACIALE\u2122 4\\nGIOCHI POLARI": [
+    "L\u2019ERA GLACIALE\u2122 4\nGIOCHI POLARI": [
         "AQLI"
     ],
-    "M & S at the London 2012\\nOlympic Games": [
+    "M & S at the London 2012\nOlympic Games": [
         "ACME",
         "ACMK",
         "ACMP"
     ],
-    "M & S at the Rio 2016\\nOlympic Games": [
+    "M & S at the Rio 2016\nOlympic Games": [
         "BGXE",
         "BGXJ",
         "BGXP"
@@ -1548,38 +1548,38 @@
         "AMKP",
         "AMKW"
     ],
-    "MEDAROT7\\nKABUTO Ver.": [
+    "MEDAROT7\nKABUTO Ver.": [
         "AQBJ"
     ],
-    "MEDAROT7\\nKUWAGATA Ver.": [
+    "MEDAROT7\nKUWAGATA Ver.": [
         "AQWJ"
     ],
-    "MEDAROT8\\nKABUTO Ver.": [
+    "MEDAROT8\nKABUTO Ver.": [
         "BMKJ"
     ],
-    "MEDAROT8\\nKUWAGATA Ver.": [
+    "MEDAROT8\nKUWAGATA Ver.": [
         "BMQJ"
     ],
-    "MEDAROT9\\nKABUTO Ver.": [
+    "MEDAROT9\nKABUTO Ver.": [
         "BA9J"
     ],
-    "MEDAROT9\\nKUWAGATA Ver.": [
+    "MEDAROT9\nKUWAGATA Ver.": [
         "BB9J"
     ],
-    "METAL GEAR SOLID\\nSNAKE EATER 3D": [
+    "METAL GEAR SOLID\nSNAKE EATER 3D": [
         "AMGE",
         "AMGJ",
         "AMGP"
     ],
-    "METALMAX4\\nDiva of The Moonlight": [
+    "METALMAX4\nDiva of The Moonlight": [
         "AX4J"
     ],
-    "METROID PRIME\\nFEDERATION FORCE": [
+    "METROID PRIME\nFEDERATION FORCE": [
         "BCAE",
         "BCAJ",
         "BCAP"
     ],
-    "METROID\\nSamus Returns": [
+    "METROID\nSamus Returns": [
         "A9AE",
         "A9AJ",
         "A9AP"
@@ -1621,7 +1621,7 @@
     "MONSTER HUNTER X": [
         "BXXJ"
     ],
-    "MONSTER HUNTER\\nGENERATIONS": [
+    "MONSTER HUNTER\nGENERATIONS": [
         "BXXE",
         "BXXP"
     ],
@@ -1638,21 +1638,21 @@
         "AMDE",
         "AMDP"
     ],
-    "Mahjong 3D\\nWarriors of the Emperor": [
+    "Mahjong 3D\nWarriors of the Emperor": [
         "AMZE",
         "AMZP"
     ],
-    "Mahjong Mysteries\\nAncient Athena 3D": [
+    "Mahjong Mysteries\nAncient Athena 3D": [
         "AM5P"
     ],
-    "Mahjongg Mysteries\\nAncient Athena 3D": [
+    "Mahjongg Mysteries\nAncient Athena 3D": [
         "AM5Z"
     ],
     "Maple Story": [
         "BMPJ",
         "BMPK"
     ],
-    "Mario & Luigi: Bowser's Inside\\nStory + Bowser Jr": [
+    "Mario & Luigi: Bowser's Inside\nStory + Bowser Jr": [
         "A3RE",
         "A3RJ",
         "A3RP"
@@ -1664,15 +1664,15 @@
         "AYNE",
         "AYNJ"
     ],
-    "Mario & Luigi: Superstar Saga\\n+ Bowser's Minions": [
+    "Mario & Luigi: Superstar Saga\n+ Bowser's Minions": [
         "BRME",
         "BRMJ",
         "BRMP"
     ],
-    "Mario & Luigi\\nDream Team Bros.": [
+    "Mario & Luigi\nDream Team Bros.": [
         "AYMP"
     ],
-    "Mario & Luigi\\nDream Team": [
+    "Mario & Luigi\nDream Team": [
         "AYME"
     ],
     "Mario Golf: World Tour": [
@@ -1706,13 +1706,13 @@
         "AGAP",
         "AGAW"
     ],
-    "Mario vs. Donkey Kong\\nTipping Stars": [
+    "Mario vs. Donkey Kong\nTipping Stars": [
         "JYLJ"
     ],
-    "Mario&Luigi RPG4\\nDreamAdventure": [
+    "Mario&Luigi RPG4\nDreamAdventure": [
         "AYMJ"
     ],
-    "Marvel Super Hero Squad\\nThe Infinity Gauntlet": [
+    "Marvel Super Hero Squad\nThe Infinity Gauntlet": [
         "AMSE",
         "AMSP"
     ],
@@ -1722,16 +1722,16 @@
     "Me & My furry Patients 3D": [
         "BMTP"
     ],
-    "Medarot DUAL\\nKABUTO Ver.": [
+    "Medarot DUAL\nKABUTO Ver.": [
         "AQVJ"
     ],
-    "Medarot DUAL\\nKUWAGATA Ver.": [
+    "Medarot DUAL\nKUWAGATA Ver.": [
         "AQAJ"
     ],
-    "Medarot Girls Mission\\nKABUTO Ver.": [
+    "Medarot Girls Mission\nKABUTO Ver.": [
         "BGPJ"
     ],
-    "Medarot Girls Mission\\nKUWAGATA Ver.": [
+    "Medarot Girls Mission\nKUWAGATA Ver.": [
         "BGQJ"
     ],
     "Mega Man Legacy Collection": [
@@ -1741,7 +1741,7 @@
     "Mensa Academy": [
         "AMMP"
     ],
-    "Michael Jackson\\nThe Experience 3D": [
+    "Michael Jackson\nThe Experience 3D": [
         "AMJE",
         "AMJP"
     ],
@@ -1757,7 +1757,7 @@
         "AM4E",
         "AM4P"
     ],
-    "Monster High -\\nNew Ghoul in School": [
+    "Monster High -\nNew Ghoul in School": [
         "BMSE",
         "BMSP"
     ],
@@ -1768,17 +1768,17 @@
     "Monster High\u2122: 13 Wishes\u2122": [
         "AEFE"
     ],
-    "Monster High\u2122\\nSkultimate Roller Maze": [
+    "Monster High\u2122\nSkultimate Roller Maze": [
         "AH5P"
     ],
-    "Monster High\u2122\\nSkultimate Roller Maze\u2122": [
+    "Monster High\u2122\nSkultimate Roller Maze\u2122": [
         "AH5E"
     ],
-    "Moshi Monsters\u2122\\nKatsuma Unleashed": [
+    "Moshi Monsters\u2122\nKatsuma Unleashed": [
         "ADME",
         "ADMP"
     ],
-    "Moshi Monsters\u2122\\nMoshlings\u2122 Theme Park": [
+    "Moshi Monsters\u2122\nMoshlings\u2122 Theme Park": [
         "AA9E",
         "AA9P"
     ],
@@ -1819,25 +1819,25 @@
     "My Pet School 3D": [
         "BM6P"
     ],
-    "My Vet Practice 3D\\nIn the country": [
+    "My Vet Practice 3D\nIn the country": [
         "AERP"
     ],
     "My Western Horse 3D": [
         "AZHP"
     ],
-    "My Zoo Vet\\nPractice 3D": [
+    "My Zoo Vet\nPractice 3D": [
         "ATXP"
     ],
-    "Mystery Case Files:\\nDire Grove": [
+    "Mystery Case Files:\nDire Grove": [
         "ADHP"
     ],
-    "Mystery Case Files:\\nRavenhearst": [
+    "Mystery Case Files:\nRavenhearst": [
         "AAQP"
     ],
-    "Mystery Case Files:\\nReturn to Ravenhearst": [
+    "Mystery Case Files:\nReturn to Ravenhearst": [
         "AR2P"
     ],
-    "Mystery Murders:\\nJack the Ripper": [
+    "Mystery Murders:\nJack the Ripper": [
         "AAJP"
     ],
     "NANO ASSAULT": [
@@ -1847,17 +1847,17 @@
         "AN4E",
         "AN4P"
     ],
-    "NARUTO SHIPPUDEN 3D\\nThe New ERA": [
+    "NARUTO SHIPPUDEN 3D\nThe New ERA": [
         "ANTF",
         "ANTP"
     ],
-    "NARUTO-\u30ca\u30eb\u30c8- \u75be\u98a8\u4f1d\\n\u5fcd\u7acb\u4f53\u7d75\u5dfb\uff01\u6700\u5f37\u5fcd\u754c\u6c7a\u6226\uff01\uff01": [
+    "NARUTO-\u30ca\u30eb\u30c8- \u75be\u98a8\u4f1d\n\u5fcd\u7acb\u4f53\u7d75\u5dfb\uff01\u6700\u5f37\u5fcd\u754c\u6c7a\u6226\uff01\uff01": [
         "ANTJ"
     ],
     "NASCAR\u00ae Unleashed": [
         "AC9E"
     ],
-    "NCIS\u2122 3D\\nBASED ON THE TV SERIES": [
+    "NCIS\u2122 3D\nBASED ON THE TV SERIES": [
         "ANCE",
         "ANCP"
     ],
@@ -1885,7 +1885,7 @@
         "AACJ",
         "AACP"
     ],
-    "New Atelier Rorona\\nStory of the beginning": [
+    "New Atelier Rorona\nStory of the beginning": [
         "BRAJ"
     ],
     "New SUPER MARIO BROS. 2": [
@@ -1903,35 +1903,35 @@
         "AS9E",
         "AS9J"
     ],
-    "Nintendo 3DS Guide: Louvre\\n(Deutsche Version)": [
+    "Nintendo 3DS Guide: Louvre\n(Deutsche Version)": [
         "AL8D"
     ],
-    "Nintendo 3DS Guide: Louvre\\n(English Version)": [
+    "Nintendo 3DS Guide: Louvre\n(English Version)": [
         "AL8P"
     ],
-    "Nintendo 3DS Guide: Louvre\\n(Version fran\u00e7aise)": [
+    "Nintendo 3DS Guide: Louvre\n(Version fran\u00e7aise)": [
         "AL8F"
     ],
-    "Nintendo 3DS Guide: Louvre\\n(Versione italiana)": [
+    "Nintendo 3DS Guide: Louvre\n(Versione italiana)": [
         "AL8I"
     ],
-    "Nintendo 3DS Guide: Louvre\\n(versi\u00f3n en espa\u00f1ol)": [
+    "Nintendo 3DS Guide: Louvre\n(versi\u00f3n en espa\u00f1ol)": [
         "AL8S"
     ],
     "Nintendo 3DS Guide: Louvre": [
         "AL8J",
         "AL8K"
     ],
-    "Nintendo Presents\\nNew Style Boutique 3": [
+    "Nintendo Presents\nNew Style Boutique 3": [
         "AJBP"
     ],
-    "Nintendo presents:\\nNew Style Boutique": [
+    "Nintendo presents:\nNew Style Boutique": [
         "ACLP"
     ],
-    "Nintendo presents\\nNew Style Boutique 2": [
+    "Nintendo presents\nNew Style Boutique 2": [
         "ECDP"
     ],
-    "Nintendo presents\\nStyle Savvy: Fashion Forward": [
+    "Nintendo presents\nStyle Savvy: Fashion Forward": [
         "ECDE"
     ],
     "Nobunaga's Ambition 2": [
@@ -1940,18 +1940,18 @@
     "Nobunaga's Ambition": [
         "BNBJ"
     ],
-    "ONE PIECE\\nROMANCE DAWN": [
+    "ONE PIECE\nROMANCE DAWN": [
         "BRDP",
         "BRDZ"
     ],
-    "ONE PIECE\\nUNLIMITED WORLD R": [
+    "ONE PIECE\nUNLIMITED WORLD R": [
         "BUWJ"
     ],
-    "ONE PIECE\\nUnlimited World Red": [
+    "ONE PIECE\nUnlimited World Red": [
         "BUWE",
         "BUWP"
     ],
-    "ONE PIECE\\n\u5927\u6d77\u8cca\u95d8\u6280\u5834": [
+    "ONE PIECE\n\u5927\u6d77\u8cca\u95d8\u6280\u5834": [
         "BUZJ"
     ],
     "OSYARENA KOINU 3D": [
@@ -1960,10 +1960,10 @@
     "Ocha-Ken To Itsumo Nakayoshi": [
         "AE3J"
     ],
-    "One Piece\\nUnlimited Cruise SP 2": [
+    "One Piece\nUnlimited Cruise SP 2": [
         "AL9P"
     ],
-    "One Piece\\nUnlimited Cruise SP": [
+    "One Piece\nUnlimited Cruise SP": [
         "ALFP"
     ],
     "Order Up!!": [
@@ -1975,19 +1975,19 @@
     "Oshaberi Usagi": [
         "AUGJ"
     ],
-    "Outback Pet\\nRescue 3D": [
+    "Outback Pet\nRescue 3D": [
         "BM4P"
     ],
-    "Outdoors Unleashed\\nAfrica 3D": [
+    "Outdoors Unleashed\nAfrica 3D": [
         "AFKP"
     ],
-    "Oxford Reading Tree\\nFloppy's Phonics vol.1": [
+    "Oxford Reading Tree\nFloppy's Phonics vol.1": [
         "AFZJ"
     ],
-    "Oxford Reading Tree\\nFloppy's Phonics vol.2": [
+    "Oxford Reading Tree\nFloppy's Phonics vol.2": [
         "AX2J"
     ],
-    "Oxford Reading Tree\\nFloppy's Phonics vol.3": [
+    "Oxford Reading Tree\nFloppy's Phonics vol.3": [
         "AX3J"
     ],
     "PAC-MAN GHOSTLY ADV 2": [
@@ -2000,22 +2000,22 @@
         "AP9J",
         "AP9P"
     ],
-    "PAC-MAN\u2122\\nand the Ghostly Adventures": [
+    "PAC-MAN\u2122\nand the Ghostly Adventures": [
         "AEJE",
         "AEJJ",
         "AEJP"
     ],
-    "PAPER MARIO\\nSticker Star": [
+    "PAPER MARIO\nSticker Star": [
         "AG5E",
         "AG5J",
         "AG5K",
         "AG5P",
         "AG5W"
     ],
-    "PERSONAQ2\\nNEW CINEMA LABYRINTH": [
+    "PERSONAQ2\nNEW CINEMA LABYRINTH": [
         "AQ2J"
     ],
-    "PERSONAQ\\nSHADOW OF THE LABYRINTH": [
+    "PERSONAQ\nSHADOW OF THE LABYRINTH": [
         "AQQJ"
     ],
     "PES 2011 3D": [
@@ -2032,7 +2032,7 @@
         "AWTI",
         "AWTP"
     ],
-    "POMPOMPURIN\\nKoroKoro Adventures": [
+    "POMPOMPURIN\nKoroKoro Adventures": [
         "BP6J"
     ],
     "POYOPOYO": [
@@ -2041,16 +2041,16 @@
     "PROFESSIONAL BASEBALL SPIRITS 2011": [
         "APSJ"
     ],
-    "PROFESSOR LAYTON\\nVS ACE ATTORNEY": [
+    "PROFESSOR LAYTON\nVS ACE ATTORNEY": [
         "AVSJ"
     ],
     "PROJECT CROSS ZONE 2 ": [
         "BX2K"
     ],
-    "PROJECT X ZONE 2\\nBRAVE NEW WORLD": [
+    "PROJECT X ZONE 2\nBRAVE NEW WORLD": [
         "BX2J"
     ],
-    "PROJECT X ZONE 2\\nORIGINAL GAME SOUND": [
+    "PROJECT X ZONE 2\nORIGINAL GAME SOUND": [
         "BXPJ"
     ],
     "PROJECT X ZONE 2": [
@@ -2060,42 +2060,42 @@
     "PROJECT X ZONE": [
         "AXXJ"
     ],
-    "PUZZLE & DRAGONS CROSS\\nDRAGON type": [
+    "PUZZLE & DRAGONS CROSS\nDRAGON type": [
         "BPVJ"
     ],
-    "PUZZLE & DRAGONS CROSS\\nGOD type": [
+    "PUZZLE & DRAGONS CROSS\nGOD type": [
         "BPWJ"
     ],
-    "PUZZLE & DRAGONS\\nSUPER MARIO BROS. EDITION": [
+    "PUZZLE & DRAGONS\nSUPER MARIO BROS. EDITION": [
         "AZMJ"
     ],
     "PUZZLE BOBBLE UNIVERSE": [
         "ABBP"
     ],
-    "Pac-Man & Galaga\\nDimensions": [
+    "Pac-Man & Galaga\nDimensions": [
         "APGE",
         "APGJ",
         "APGP"
     ],
-    "Paddington:\\nAdventures in London": [
+    "Paddington:\nAdventures in London": [
         "BPLE",
         "BPLP"
     ],
-    "Paws & Claws\\nPampered Pets Resort 3D": [
+    "Paws & Claws\nPampered Pets Resort 3D": [
         "AP8E"
     ],
     "Pazuru": [
         "BPZP"
     ],
-    "Persona Q2\\nNew Cinema Labyrinth": [
+    "Persona Q2\nNew Cinema Labyrinth": [
         "AQ2E",
         "AQ2P"
     ],
-    "Persona Q:\\nShadow of the Labyrinth": [
+    "Persona Q:\nShadow of the Labyrinth": [
         "AQQE",
         "AQQP"
     ],
-    "PersonaQ\\nShadow Of The Labyrinth": [
+    "PersonaQ\nShadow Of The Labyrinth": [
         "AQQK"
     ],
     "Pet Zombies": [
@@ -2108,28 +2108,28 @@
         "APFE",
         "APFP"
     ],
-    "Petz\u00ae\\nBeach": [
+    "Petz\u00ae\nBeach": [
         "APIE",
         "APIP"
     ],
-    "Petz\u00ae\\nCountryside": [
+    "Petz\u00ae\nCountryside": [
         "APOE",
         "APOP"
     ],
-    "Phineas & Ferb:\\nQuest For Cool Stuff": [
+    "Phineas & Ferb:\nQuest For Cool Stuff": [
         "AAWE",
         "AAWP"
     ],
-    "Phoenix Wright: Ace Attorney\\nSpirit of Justice": [
+    "Phoenix Wright: Ace Attorney\nSpirit of Justice": [
         "BG6J"
     ],
-    "Phonics Fun with Biff,\\nChip and Kipper vol.1": [
+    "Phonics Fun with Biff,\nChip and Kipper vol.1": [
         "AFZP"
     ],
-    "Phonics Fun with Biff,\\nChip and Kipper vol.2": [
+    "Phonics Fun with Biff,\nChip and Kipper vol.2": [
         "AX2P"
     ],
-    "Phonics Fun with Biff,\\nChip and Kipper vol.3": [
+    "Phonics Fun with Biff,\nChip and Kipper vol.3": [
         "AX3P"
     ],
     "Picross 3D: Round 2": [
@@ -2140,7 +2140,7 @@
         "AWAJ",
         "AWAP"
     ],
-    "Pinball Hall of Fame:\\nThe Williams Collection 3D": [
+    "Pinball Hall of Fame:\nThe Williams Collection 3D": [
         "APBE",
         "APBP"
     ],
@@ -2158,11 +2158,11 @@
     "Pok\u00e9mon Moon": [
         "BNEA"
     ],
-    "Pok\u00e9mon Mystery Dungeon\\nGates to Infinity": [
+    "Pok\u00e9mon Mystery Dungeon\nGates to Infinity": [
         "APDE",
         "APDP"
     ],
-    "Pokemon Mystery Dungeon\\nMagna gate and infinity ": [
+    "Pokemon Mystery Dungeon\nMagna gate and infinity ": [
         "APDJ"
     ],
     "Pok\u00e9mon Omega Ruby": [
@@ -2189,7 +2189,7 @@
     "Pok\u00e9mon Y": [
         "EK2A"
     ],
-    "Pok\u00e9mon\\nSuper Mystery Dungeon": [
+    "Pok\u00e9mon\nSuper Mystery Dungeon": [
         "BPXE",
         "BPXJ",
         "BPXP"
@@ -2202,15 +2202,15 @@
     "Poptropica: Forgotten Islands": [
         "BPFE"
     ],
-    "Power Rangers\\nMegaforce": [
+    "Power Rangers\nMegaforce": [
         "AZBE",
         "AZBP"
     ],
-    "Power Rangers\\nSuper Megaforce": [
+    "Power Rangers\nSuper Megaforce": [
         "BSSE",
         "BSSP"
     ],
-    "PriPri Chi-chan!!\\nPriPri Decoroom": [
+    "PriPri Chi-chan!!\nPriPri Decoroom": [
         "B2CJ"
     ],
     "Pro Evolution Soccer 2011 3D": [
@@ -2222,41 +2222,41 @@
     "Pro Evolution Soccer 2013 3D": [
         "AWTE"
     ],
-    "Professeur Layton\\net le masque des miracles": [
+    "Professeur Layton\net le masque des miracles": [
         "AKKF"
     ],
-    "Professeur Layton\\net l\u2019h\u00e9ritage des Aslantes": [
+    "Professeur Layton\net l\u2019h\u00e9ritage des Aslantes": [
         "AL6F"
     ],
-    "Professional Baseball\\nFamista2011": [
+    "Professional Baseball\nFamista2011": [
         "AFSJ"
     ],
-    "Professor Layton vs\\nPhoenix Wright: Ace Attorney": [
+    "Professor Layton vs\nPhoenix Wright: Ace Attorney": [
         "AVSE",
         "AVSP",
         "AVSZ"
     ],
-    "Professor Layton\\nand the Azran Legacy": [
+    "Professor Layton\nand the Azran Legacy": [
         "AL6E",
         "AL6P"
     ],
-    "Professor Layton\\nand the Mask of Miracle": [
+    "Professor Layton\nand the Mask of Miracle": [
         "AKKJ"
     ],
-    "Professor Layton\\nand the Miracle Mask": [
+    "Professor Layton\nand the Miracle Mask": [
         "AKKE",
         "AKKP"
     ],
-    "Professor Layton\\nen de Erfenis van de Azran": [
+    "Professor Layton\nen de Erfenis van de Azran": [
         "AL6H"
     ],
-    "Professor Layton\\nen het Masker der Wonderen": [
+    "Professor Layton\nen het Masker der Wonderen": [
         "AKKH"
     ],
-    "Professor Layton\\nund das Verm\u00e4chtnis von Aslant": [
+    "Professor Layton\nund das Verm\u00e4chtnis von Aslant": [
         "AL6D"
     ],
-    "Professor Layton\\nund die Maske der Wunder": [
+    "Professor Layton\nund die Maske der Wunder": [
         "AKKD"
     ],
     "Project X Zone": [
@@ -2283,7 +2283,7 @@
     "Puyopuyo Tetris": [
         "BPTJ"
     ],
-    "Puzzle & Dragons Z +\\nSuper Mario Bros. Edition": [
+    "Puzzle & Dragons Z +\nSuper Mario Bros. Edition": [
         "AZGE",
         "AZGP"
     ],
@@ -2305,7 +2305,7 @@
     "RABBIDS 3D": [
         "ARBP"
     ],
-    "RABBIDS\\nTRAVEL IN TIME": [
+    "RABBIDS\nTRAVEL IN TIME": [
         "ARBE"
     ],
     "RAYMAN ORIGINS": [
@@ -2313,16 +2313,16 @@
         "ARMJ",
         "ARMP"
     ],
-    "RESIDENT EVIL\u00ae\\nREVELATIONS": [
+    "RESIDENT EVIL\u00ae\nREVELATIONS": [
         "ABRE"
     ],
-    "RESIDENT EVIL\u00ae\\nTHE MERCENARIES 3D": [
+    "RESIDENT EVIL\u00ae\nTHE MERCENARIES 3D": [
         "ABME"
     ],
-    "RESIDENT EVIL\u2122\\nREVELATIONS": [
+    "RESIDENT EVIL\u2122\nREVELATIONS": [
         "ABRP"
     ],
-    "RESIDENT EVIL\u2122\\nTHE MERCENARIES 3D": [
+    "RESIDENT EVIL\u2122\nTHE MERCENARIES 3D": [
         "ABMP"
     ],
     "RIDGE RACER 3D": [
@@ -2339,14 +2339,14 @@
         "BRPJ",
         "BRPP"
     ],
-    "Rabbids\\nRumble": [
+    "Rabbids\nRumble": [
         "AR5E",
         "AR5P"
     ],
-    "Rabbids\\nTravel In Time": [
+    "Rabbids\nTravel In Time": [
         "ARBJ"
     ],
-    "Radiant Historia:\\nPerfect Chronology": [
+    "Radiant Historia:\nPerfect Chronology": [
         "BRBE",
         "BRBP"
     ],
@@ -2354,7 +2354,7 @@
         "ARYE",
         "ARYP"
     ],
-    "Rayman and Rabbids\\n- Family Pack": [
+    "Rayman and Rabbids\n- Family Pack": [
         "BRRP"
     ],
     "Real Heroes: FireFighter 3D": [
@@ -2366,17 +2366,17 @@
         "ARFE",
         "ARFP"
     ],
-    "Regular Show\\nM&RI8BL": [
+    "Regular Show\nM&RI8BL": [
         "AEBE",
         "AEBP"
     ],
-    "Return to PopoloCrois:\\nA STORY OF SEASONS Fairyt": [
+    "Return to PopoloCrois:\nA STORY OF SEASONS Fairyt": [
         "BPPE"
     ],
     "Rhythm Paradise Megamix": [
         "BPJP"
     ],
-    "Rhythm Thief\\n& the Emperor's Treasure": [
+    "Rhythm Thief\n& the Emperor's Treasure": [
         "ARTE",
         "ARTJ",
         "ARTP"
@@ -2384,19 +2384,19 @@
     "Ridge Racer 3D": [
         "ARRJ"
     ],
-    "Riding Stables 3D\\nJumping for the Team": [
+    "Riding Stables 3D\nJumping for the Team": [
         "AAPP"
     ],
-    "Riding Stables 3D\\nRivals in the Saddle": [
+    "Riding Stables 3D\nRivals in the Saddle": [
         "AMUP"
     ],
     "Riding Star 3D": [
         "ARSP"
     ],
-    "Rilakkuma\\nnakayoshi collection": [
+    "Rilakkuma\nnakayoshi collection": [
         "BGYJ"
     ],
-    "Rilu Rilu Fairilu\\nMy First Fairilu Magic\u266a": [
+    "Rilu Rilu Fairilu\nMy First Fairilu Magic\u266a": [
         "AR8J"
     ],
     "River City: RIVAL SHOWDOWN": [
@@ -2421,11 +2421,11 @@
     "RuneFactory4": [
         "AR4J"
     ],
-    "SAMURAI WARRIORS:\\nChronicles": [
+    "SAMURAI WARRIORS:\nChronicles": [
         "A66E",
         "A66P"
     ],
-    "SD GUNDAM\\nGGENERATION 3D": [
+    "SD GUNDAM\nGGENERATION 3D": [
         "AGJJ"
     ],
     "SEGA 3D Archives": [
@@ -2443,7 +2443,7 @@
         "BNUJ",
         "BNUK"
     ],
-    "SENRAN KAGURA 2:\\nDeep Crimson": [
+    "SENRAN KAGURA 2:\nDeep Crimson": [
         "BNUE",
         "BNUP"
     ],
@@ -2460,13 +2460,13 @@
     "SHOKUGEKI_NO_SOMA": [
         "BYDJ"
     ],
-    "SIMPLEseries for Nintendo 3DS\\nVol.1 THE MAHJONG": [
+    "SIMPLEseries for Nintendo 3DS\nVol.1 THE MAHJONG": [
         "AAUJ"
     ],
-    "SIMPLE\uff7c\uff98\uff70\uff7d\uff9e for \uff86\uff9d\uff83\uff9d\uff84\uff9e\uff703DS\\nVol.2 THE\u5bc6\u5ba4\u304b\u3089\u306e\u8131\u51fa \uff71\uff70\uff76\uff72": [
+    "SIMPLE\uff7c\uff98\uff70\uff7d\uff9e for \uff86\uff9d\uff83\uff9d\uff84\uff9e\uff703DS\nVol.2 THE\u5bc6\u5ba4\u304b\u3089\u306e\u8131\u51fa \uff71\uff70\uff76\uff72": [
         "BYEJ"
     ],
-    "SIMPLE\uff7c\uff98\uff70\uff7d\uff9e for \uff86\uff9d\uff83\uff9d\uff84\uff9e\uff703DS\\nVol.3 THE\u5bc6\u5ba4\u304b\u3089\u306e\u8131\u51fa \uff71\uff70\uff76\uff72": [
+    "SIMPLE\uff7c\uff98\uff70\uff7d\uff9e for \uff86\uff9d\uff83\uff9d\uff84\uff9e\uff703DS\nVol.3 THE\u5bc6\u5ba4\u304b\u3089\u306e\u8131\u51fa \uff71\uff70\uff76\uff72": [
         "BP3J"
     ],
     "SONIC GENERATIONS": [
@@ -2491,7 +2491,7 @@
         "BS3J",
         "BS3P"
     ],
-    "STORY OF SEASONS:\\nTrio of Towns": [
+    "STORY OF SEASONS:\nTrio of Towns": [
         "BB3E",
         "BB3P"
     ],
@@ -2499,7 +2499,7 @@
         "BTSE",
         "BTSP"
     ],
-    "SUDOKU\\n-The Puzzle Game Collection-": [
+    "SUDOKU\n-The Puzzle Game Collection-": [
         "AS9P"
     ],
     "SUPER MARIO 3D LAND": [
@@ -2515,7 +2515,7 @@
         "ASMJ",
         "ASMP"
     ],
-    "SUPER STREET FIGHTER \u2163\\n3D EDITION": [
+    "SUPER STREET FIGHTER \u2163\n3D EDITION": [
         "ASSE",
         "ASSJ",
         "ASSP"
@@ -2529,10 +2529,10 @@
     "Sayonara Umihara Kawase": [
         "AUFJ"
     ],
-    "Schlag den Raab\\nDas 2. Spiel": [
+    "Schlag den Raab\nDas 2. Spiel": [
         "AS2D"
     ],
-    "Scooby-Doo! & Looney Tunes\\nCartoon Universe: Adv": [
+    "Scooby-Doo! & Looney Tunes\nCartoon Universe: Adv": [
         "BCUE"
     ],
     "Scribblenauts Unlimited": [
@@ -2540,17 +2540,17 @@
         "ASLP",
         "ASLX"
     ],
-    "Scribblenauts Unmasked\\nA DC Comics Adventure": [
+    "Scribblenauts Unmasked\nA DC Comics Adventure": [
         "AD6E",
         "AD6P"
     ],
     "Secret Agent Files: Miami": [
         "ASAP"
     ],
-    "Secret Mysteries\\nIn London": [
+    "Secret Mysteries\nIn London": [
         "ASXP"
     ],
-    "Secrets of the Titanic\\n1912-2012": [
+    "Secrets of the Titanic\n1912-2012": [
         "ASEP"
     ],
     "Sekaiju to Fushigi no Dungeon2": [
@@ -2567,7 +2567,7 @@
         "AJAP",
         "BP8J"
     ],
-    "Sherlock Holmes:\\nthe Mystery of the Frozen City": [
+    "Sherlock Holmes:\nthe Mystery of the Frozen City": [
         "AHAJ",
         "AHAP"
     ],
@@ -2575,26 +2575,26 @@
         "ASZE",
         "ASZP"
     ],
-    "Shin Megami Tensei IV:\\nApocalypse": [
+    "Shin Megami Tensei IV:\nApocalypse": [
         "BG4E",
         "BG4P"
     ],
     "Shin Megami Tensei IV": [
         "AMXE"
     ],
-    "Shin Megami Tensei:\\nDevil Summoner: Soul Hackers": [
+    "Shin Megami Tensei:\nDevil Summoner: Soul Hackers": [
         "AHQE",
         "AHQP"
     ],
-    "Shin Megami Tensei:\\nDevil Survivor Overclocked": [
+    "Shin Megami Tensei:\nDevil Survivor Overclocked": [
         "AMTE",
         "AMTP"
     ],
-    "Shin Megami Tensei:\\nStrange Journey Redux": [
+    "Shin Megami Tensei:\nStrange Journey Redux": [
         "AJ9E",
         "AJ9P"
     ],
-    "Shin Megami Tensei\\nDEEP STRANGE JOURNEY": [
+    "Shin Megami Tensei\nDEEP STRANGE JOURNEY": [
         "AJ9J"
     ],
     "Shinobi\u2122 3D": [
@@ -2628,37 +2628,37 @@
     "Skylanders\u00ae SuperChargers": [
         "BL5E"
     ],
-    "Skylanders\\nSpyro's Adventure": [
+    "Skylanders\nSpyro's Adventure": [
         "ASPE",
         "ASPJ",
         "ASPP"
     ],
-    "Sonic & All-Stars Racing\\nTransformed": [
+    "Sonic & All-Stars Racing\nTransformed": [
         "ALLE",
         "ALLP"
     ],
-    "Sonic Boom:\\nFire & Ice": [
+    "Sonic Boom:\nFire & Ice": [
         "BS6E",
         "BS6P"
     ],
-    "Sonic Boom:\\nShattered Crystal": [
+    "Sonic Boom:\nShattered Crystal": [
         "BSYE",
         "BSYP"
     ],
-    "Sonic Toon:\\nFire & Ice": [
+    "Sonic Toon:\nFire & Ice": [
         "BS6J"
     ],
-    "Sonic Toon:\\nIsland Adventure": [
+    "Sonic Toon:\nIsland Adventure": [
         "BSYJ"
     ],
     "Spider-Man\u2122: Edge of Time": [
         "AS7E",
         "AS7P"
     ],
-    "Spider-Man\u2122:\\nAux fronti\u00e8res du temps": [
+    "Spider-Man\u2122:\nAux fronti\u00e8res du temps": [
         "AS7F"
     ],
-    "Spirit Camera\\nThe Cursed Memoir": [
+    "Spirit Camera\nThe Cursed Memoir": [
         "ALCE",
         "ALCP"
     ],
@@ -2666,7 +2666,7 @@
         "BPNE",
         "BPNP"
     ],
-    "SpongeBob SquarePants:\\nPlankton's Robotic Reveng": [
+    "SpongeBob SquarePants:\nPlankton's Robotic Reveng": [
         "ANXE",
         "ANXP"
     ],
@@ -2688,16 +2688,16 @@
         "ANRE",
         "ANRP"
     ],
-    "Starry\u2606Sky\\n\uff5ein Autumn\uff5e 3D": [
+    "Starry\u2606Sky\n\uff5ein Autumn\uff5e 3D": [
         "AX6J"
     ],
-    "Starry\u2606Sky\\n\uff5ein Spring\uff5e 3D": [
+    "Starry\u2606Sky\n\uff5ein Spring\uff5e 3D": [
         "AAXJ"
     ],
-    "Starry\u2606Sky\\n\uff5ein Summer\uff5e 3D": [
+    "Starry\u2606Sky\n\uff5ein Summer\uff5e 3D": [
         "AZPJ"
     ],
-    "Starry\u2606Sky\\n\uff5ein Winter\uff5e 3D": [
+    "Starry\u2606Sky\n\uff5ein Winter\uff5e 3D": [
         "AX7J"
     ],
     "Steel Diver": [
@@ -2705,13 +2705,13 @@
         "ASDJ",
         "ASDP"
     ],
-    "Sternenschweif 3D\\nDas Geheimnis im Zauberwald": [
+    "Sternenschweif 3D\nDas Geheimnis im Zauberwald": [
         "BSCD"
     ],
     "Style Savvy: Trendsetters": [
         "ACLE"
     ],
-    "Sudoku + 7 other\\nComplex Puzzles by Nikoli": [
+    "Sudoku + 7 other\nComplex Puzzles by Nikoli": [
         "ANQP"
     ],
     "Sudoku by NIKOLI 3D vol.2": [
@@ -2720,14 +2720,14 @@
     "Sudoku by NIKOLI 3D": [
         "ANQJ"
     ],
-    "Suichara\\nWelcome to the Sweets School!": [
+    "Suichara\nWelcome to the Sweets School!": [
         "B2SJ"
     ],
     "Super Black Bass 3D": [
         "ASBE",
         "ASBP"
     ],
-    "Super Mario Maker\\nfor Nintendo 3DS": [
+    "Super Mario Maker\nfor Nintendo 3DS": [
         "AJHE",
         "AJHJ",
         "AJHP"
@@ -2736,19 +2736,19 @@
         "ACCJ",
         "ACCP"
     ],
-    "Super Smash Bros.\\nfor Nintendo 3DS": [
+    "Super Smash Bros.\nfor Nintendo 3DS": [
         "AXCE",
         "AXCJ",
         "AXCK",
         "AXCP"
     ],
-    "Survivor 3D\\nThe Ultimate Adventure": [
+    "Survivor 3D\nThe Ultimate Adventure": [
         "AV2P"
     ],
-    "Survivor\\nHeroes": [
+    "Survivor\nHeroes": [
         "BSHP"
     ],
-    "Sushi Striker\\nThe Way of Sushido": [
+    "Sushi Striker\nThe Way of Sushido": [
         "AFWE",
         "AFWJ",
         "AFWP"
@@ -2766,7 +2766,7 @@
         "ATKK",
         "ATKP"
     ],
-    "TENKAI KNIGHTS\u2122\\nBRAVE BATTLE": [
+    "TENKAI KNIGHTS\u2122\nBRAVE BATTLE": [
         "BTKE",
         "BTKP"
     ],
@@ -2780,11 +2780,11 @@
         "AQRE",
         "AQRP"
     ],
-    "THEATRHYTHM FINAL FANTASY\\nCURTAIN CALL": [
+    "THEATRHYTHM FINAL FANTASY\nCURTAIN CALL": [
         "BTHE",
         "BTHP"
     ],
-    "THEATRHYTHM\\nFINAL FANTASY": [
+    "THEATRHYTHM\nFINAL FANTASY": [
         "ATHE",
         "ATHP"
     ],
@@ -2794,20 +2794,20 @@
     "TIME TRAVELERS": [
         "ATRJ"
     ],
-    "TOEIC\u00ae\u30c6\u30b9\u30c8\\n\u8d85\u901f\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
+    "TOEIC\u00ae\u30c6\u30b9\u30c8\n\u8d85\u901f\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
         "ATEJ"
     ],
     "TORIKO GOURMEGABATTLE!": [
         "BT5J"
     ],
-    "TRANSFORMERS 3\\nStealth Force Edition 3D": [
+    "TRANSFORMERS 3\nStealth Force Edition 3D": [
         "ATFP"
     ],
-    "TRANSFORMERS\\nPRIME": [
+    "TRANSFORMERS\nPRIME": [
         "ATPE",
         "ATPP"
     ],
-    "TRANSFORMERS\\nRise of the Dark Spark": [
+    "TRANSFORMERS\nRise of the Dark Spark": [
         "AYEE",
         "AYEP"
     ],
@@ -2815,17 +2815,17 @@
         "AANE",
         "AANP"
     ],
-    "TanoshikuOmoshiroku\\nKankenshogakusei": [
+    "TanoshikuOmoshiroku\nKankenshogakusei": [
         "A3KJ"
     ],
     "Teddy Together": [
         "AKMP"
     ],
-    "Teenage Mutant Ninja Turtles\u2122:\\nDanger of the Ooz": [
+    "Teenage Mutant Ninja Turtles\u2122:\nDanger of the Ooz": [
         "BMUE",
         "BMUP"
     ],
-    "Teenage Mutant Ninja Turtles\u2122:\\nMaster Splinter's": [
+    "Teenage Mutant Ninja Turtles\u2122:\nMaster Splinter's": [
         "BTNE",
         "BTNP"
     ],
@@ -2850,7 +2850,7 @@
     "Tetris\u00ae": [
         "ATLP"
     ],
-    "The Adventures of Tintin\\nThe Secret of the Unico": [
+    "The Adventures of Tintin\nThe Secret of the Unico": [
         "ATNE",
         "ATNJ",
         "ATNP"
@@ -2879,7 +2879,7 @@
     "The Job's Themepark 2.": [
         "AWKJ"
     ],
-    "The LEGO\u00ae Movie\\nVideogame": [
+    "The LEGO\u00ae Movie\nVideogame": [
         "AFJD",
         "AFJE",
         "AFJF",
@@ -2887,42 +2887,42 @@
         "AFJP",
         "AFJS"
     ],
-    "The Legend of Korra\u2122:\\nA New Era Begins": [
+    "The Legend of Korra\u2122:\nA New Era Begins": [
         "BLDE"
     ],
     "The Legend of Legacy": [
         "BLLE",
         "BLLP"
     ],
-    "The Legend of Zelda\\nA Link Between Worlds": [
+    "The Legend of Zelda\nA Link Between Worlds": [
         "BZLE",
         "BZLJ",
         "BZLK",
         "BZLP"
     ],
-    "The Legend of Zelda\\nMajora's Mask 3D": [
+    "The Legend of Zelda\nMajora's Mask 3D": [
         "AJRE",
         "AJRJ",
         "AJRK",
         "AJRP"
     ],
-    "The Legend of Zelda\\nOcarina of Time 3D": [
+    "The Legend of Zelda\nOcarina of Time 3D": [
         "AQEE",
         "AQEJ",
         "AQEK",
         "AQEP",
         "AQEW"
     ],
-    "The Legend of Zelda\\nTri Force Heroes": [
+    "The Legend of Zelda\nTri Force Heroes": [
         "EA3E",
         "EA3J",
         "EA3P",
         "EA3Z"
     ],
-    "The Mysterious Cities of Gold:\\nSecret Paths": [
+    "The Mysterious Cities of Gold:\nSecret Paths": [
         "BMCP"
     ],
-    "The Peanuts\u00ae Movie:\\nSnoopy's Grand Adventure": [
+    "The Peanuts\u00ae Movie:\nSnoopy's Grand Adventure": [
         "BPEE",
         "BPEP"
     ],
@@ -2930,7 +2930,7 @@
         "BPGE",
         "BPGP"
     ],
-    "The SNACK WORLD\\nTREJARERS": [
+    "The SNACK WORLD\nTREJARERS": [
         "BWSJ"
     ],
     "The Sims\u2122 3 Pets": [
@@ -2947,14 +2947,14 @@
         "ATZE",
         "ATZP"
     ],
-    "The Whitakers present\\nMilton & Friends 3D": [
+    "The Whitakers present\nMilton & Friends 3D": [
         "AM3P"
     ],
-    "Thor\u2122:\\nGod of Thunder": [
+    "Thor\u2122:\nGod of Thunder": [
         "AGTE",
         "AGTP"
     ],
-    "Tom Clancy's Ghost Recon\\nShadow Wars": [
+    "Tom Clancy's Ghost Recon\nShadow Wars": [
         "AGRE",
         "AGRJ",
         "AGRP"
@@ -2984,10 +2984,10 @@
     "Touch!DoublePenSports": [
         "APPJ"
     ],
-    "Transformers\u2122 3\\nStealth Force Edition 3D": [
+    "Transformers\u2122 3\nStealth Force Edition 3D": [
         "ATFE"
     ],
-    "Travel Adventures\\nwith Hello Kitty": [
+    "Travel Adventures\nwith Hello Kitty": [
         "AHKE"
     ],
     "ULTIMATE NES REMIX": [
@@ -2997,31 +2997,31 @@
         "BFRE",
         "BFRJ"
     ],
-    "Ultra baseball\\nAction card battle": [
+    "Ultra baseball\nAction card battle": [
         "BUBJ"
     ],
-    "Viking Invasion 2\\nTower Defense": [
+    "Viking Invasion 2\nTower Defense": [
         "AVKP"
     ],
     "Virtue's Last Reward": [
         "AKGP"
     ],
-    "VitaminX\\nEvolution Plus": [
+    "VitaminX\nEvolution Plus": [
         "BVXJ"
     ],
-    "VitaminZ\\nRevolution": [
+    "VitaminZ\nRevolution": [
         "BVZJ"
     ],
-    "WORLD SOCCER\\nWinning Eleven 2012": [
+    "WORLD SOCCER\nWinning Eleven 2012": [
         "AE2J"
     ],
-    "WORLD SOCCER\\nWinning Eleven 2013": [
+    "WORLD SOCCER\nWinning Eleven 2013": [
         "AWTJ"
     ],
-    "WORLD SOCCER\\nWinning Eleven 2014 JE": [
+    "WORLD SOCCER\nWinning Eleven 2014 JE": [
         "BSBJ"
     ],
-    "WORLD SOCCER\\nWinning Eleven 2014": [
+    "WORLD SOCCER\nWinning Eleven 2014": [
         "BW4J"
     ],
     "WRC The Official Game": [
@@ -3037,7 +3037,7 @@
     "Winning Eleven 3DSoccer": [
         "AEEJ"
     ],
-    "Winter Sports 2012\\nFeel the Spirit": [
+    "Winter Sports 2012\nFeel the Spirit": [
         "AWSP"
     ],
     "Winx Club: Saving Alfea": [
@@ -3059,29 +3059,29 @@
     "YO-KAI SANGOKUSHI": [
         "AYKJ"
     ],
-    "YO-KAI WATCH 2:\\nBONY SPIRITS": [
+    "YO-KAI WATCH 2:\nBONY SPIRITS": [
         "BYGP"
     ],
-    "YO-KAI WATCH 2:\\nFLESHY SOULS": [
+    "YO-KAI WATCH 2:\nFLESHY SOULS": [
         "BYHP"
     ],
-    "YO-KAI WATCH 2:\\nPSYCHIC SPECTERS": [
+    "YO-KAI WATCH 2:\nPSYCHIC SPECTERS": [
         "BYSE",
         "BYSP",
         "BYSZ"
     ],
-    "YO-KAI WATCH BLASTERS\\nRED CAT CORPS": [
+    "YO-KAI WATCH BLASTERS\nRED CAT CORPS": [
         "BYAE",
         "BYAP"
     ],
-    "YO-KAI WATCH BLASTERS\\nWHITE DOG SQUAD": [
+    "YO-KAI WATCH BLASTERS\nWHITE DOG SQUAD": [
         "BYBE",
         "BYBP"
     ],
-    "YO-KAI WATCH BUSTERS 2\\nMAGNUM": [
+    "YO-KAI WATCH BUSTERS 2\nMAGNUM": [
         "BYMJ"
     ],
-    "YO-KAI WATCH BUSTERS 2\\nSWORD": [
+    "YO-KAI WATCH BUSTERS 2\nSWORD": [
         "BYNJ"
     ],
     "YO-KAI WATCH": [
@@ -3133,10 +3133,10 @@
     "Yokai Watch 3 TEMPURA": [
         "BY4J"
     ],
-    "Yokai Watch Busters\\nAkaneko Dan": [
+    "Yokai Watch Busters\nAkaneko Dan": [
         "BYAJ"
     ],
-    "Yokai Watch Busters\\nShiroinu Tai": [
+    "Yokai Watch Busters\nShiroinu Tai": [
         "BYBJ"
     ],
     "Yokai Watch": [
@@ -3145,7 +3145,7 @@
     "Young Justice\u2122: Legacy": [
         "AYJE"
     ],
-    "Yu-Gi-Oh! ZEXAL\\nWorld Duel Carnival": [
+    "Yu-Gi-Oh! ZEXAL\nWorld Duel Carnival": [
         "AYXP"
     ],
     "Yu-Gi-Oh!ZEXAL": [
@@ -3154,32 +3154,32 @@
     "ZERO ESCAPE": [
         "BZGJ"
     ],
-    "ZETSUBO YOSAI\\nescape adventure": [
+    "ZETSUBO YOSAI\nescape adventure": [
         "AZUJ"
     ],
-    "ZOO MANIA\\nBUILD YOUR DREAM ZOO": [
+    "ZOO MANIA\nBUILD YOUR DREAM ZOO": [
         "ANMJ"
     ],
     "ZOO RESORT": [
         "AZOE",
         "AZOP"
     ],
-    "Zero Escape:\\nVirtue's Last Reward": [
+    "Zero Escape:\nVirtue's Last Reward": [
         "AKGE"
     ],
-    "Zero Escape:\\nZero Time Dilemma": [
+    "Zero Escape:\nZero Time Dilemma": [
         "BZEE"
     ],
     "aikatsu!my two princesses": [
         "BAKJ"
     ],
-    "atelier deco la doll\\ncollection": [
+    "atelier deco la doll\ncollection": [
         "AULJ"
     ],
-    "attack on titan 2\\nfuture": [
+    "attack on titan 2\nfuture": [
         "AKPJ"
     ],
-    "attack on titan\\nchain": [
+    "attack on titan\nchain": [
         "BG2J"
     ],
     "attack on titan": [
@@ -3202,22 +3202,22 @@
         "AEGP",
         "AEGZ"
     ],
-    "hoppechan minnadeodekake!\\nwakuwaku hoppeland!!": [
+    "hoppechan minnadeodekake!\nwakuwaku hoppeland!!": [
         "BH2J"
     ],
-    "hoppechan tukutte!\\nasonde! punipunitown!!": [
+    "hoppechan tukutte!\nasonde! punipunitown!!": [
         "BHPJ"
     ],
-    "hoppechan\\npunittoshibotte daibouken!": [
+    "hoppechan\npunittoshibotte daibouken!": [
         "BH3J"
     ],
-    "kekiyasan monogatari\\noishiisuituwotukurou": [
+    "kekiyasan monogatari\noishiisuituwotukurou": [
         "BC8J"
     ],
     "kinkinomaguna": [
         "BKKJ"
     ],
-    "kouenji joshi soccer 3\\nkoisuruirebun itukaha hea": [
+    "kouenji joshi soccer 3\nkoisuruirebun itukaha hea": [
         "BKJJ"
     ],
     "kuniokun special": [
@@ -3246,19 +3246,19 @@
     "pikapika nurse story2": [
         "ANAJ"
     ],
-    "pikapikanasumonogatari\\nsyounikahaitumooosawagi": [
+    "pikapikanasumonogatari\nsyounikahaitumooosawagi": [
         "AG4J"
     ],
-    "sumikkogurasi\\nkoko,dokonandesu?": [
+    "sumikkogurasi\nkoko,dokonandesu?": [
         "AWHJ"
     ],
-    "sumikkogurasi\\nkokogaochitukunndesu": [
+    "sumikkogurasi\nkokogaochitukunndesu": [
         "BCNJ"
     ],
-    "sumikkogurasi\\nmurawotukurunndesu": [
+    "sumikkogurasi\nmurawotukurunndesu": [
         "BVSJ"
     ],
-    "sumikkogurasi\\nomisehazimerundesu": [
+    "sumikkogurasi\nomisehazimerundesu": [
         "BSVJ"
     ],
     "the Smurfs\u2122": [
@@ -3271,22 +3271,22 @@
     "wannyan petshop": [
         "BWNJ"
     ],
-    "wannyandoubutsubyouin\\npettonooisyasanninarou": [
+    "wannyandoubutsubyouin\npettonooisyasanninarou": [
         "BW2J"
     ],
-    "wannyandoubutsubyouin\\nsutekinajyuuisanninarou": [
+    "wannyandoubutsubyouin\nsutekinajyuuisanninarou": [
         "AWJJ"
     ],
     "\u719f\u8a9e \u901f\u5f15\u8f9e\u5178": [
         "AJXJ"
     ],
-    "\u30de\u30ae\\n\u65b0\u305f\u306a\u308b\u4e16\u754c": [
+    "\u30de\u30ae\n\u65b0\u305f\u306a\u308b\u4e16\u754c": [
         "BNWJ"
     ],
-    "\u30de\u30ae\\n\u306f\u3058\u307e\u308a\u306e\u8ff7\u5bae": [
+    "\u30de\u30ae\n\u306f\u3058\u307e\u308a\u306e\u8ff7\u5bae": [
         "ALMJ"
     ],
-    "\u30b4\u30f3\\n\u30d0\u30af\u30d0\u30af\u30d0\u30af\u30d0\u30af\u30a2\u30c9\u30d9\u30f3\u30c1\u30e3\u30fc": [
+    "\u30b4\u30f3\n\u30d0\u30af\u30d0\u30af\u30d0\u30af\u30d0\u30af\u30a2\u30c9\u30d9\u30f3\u30c1\u30e3\u30fc": [
         "AG7J"
     ],
     "\u96f7\u5b50": [
@@ -3298,10 +3298,10 @@
     "\u30c8\u30ea\u30b3 \u30b0\u30eb\u30e1\u30e2\u30f3\u30b9\u30bf\u30fc\u30ba\uff01": [
         "AT6J"
     ],
-    "\u85e4\u5b50\u30fbF\u30fb\u4e0d\u4e8c\u96c4\u30ad\u30e3\u30e9\u30af\u30bf\u30fc\u30ba\\n\u5927\u96c6\u5408\uff01SF\u30c9\u30bf\u30d0\u30bf\u30d1\u30fc\u30c6\u30a3\u30fc\uff01\uff01": [
+    "\u85e4\u5b50\u30fbF\u30fb\u4e0d\u4e8c\u96c4\u30ad\u30e3\u30e9\u30af\u30bf\u30fc\u30ba\n\u5927\u96c6\u5408\uff01SF\u30c9\u30bf\u30d0\u30bf\u30d1\u30fc\u30c6\u30a3\u30fc\uff01\uff01": [
         "BFPJ"
     ],
-    "\u8b0e\u60d1\u9928\\n\u97f3\u306e\u9593\u306b\u9593\u306b": [
+    "\u8b0e\u60d1\u9928\n\u97f3\u306e\u9593\u306b\u9593\u306b": [
         "ANWJ"
     ],
     "\u4e09\u570b\u5fd7": [
@@ -3310,10 +3310,10 @@
     "\u6226\u56fd\u7121\u53cc Chronicle \uff13": [
         "BC4J"
     ],
-    "\u9b54\u754c\u738b\u5b50 devils and realist\\n\u4ee3\u7406\u738b\u306e\u79d8\u5b9d": [
+    "\u9b54\u754c\u738b\u5b50 devils and realist\n\u4ee3\u7406\u738b\u306e\u79d8\u5b9d": [
         "BDPJ"
     ],
-    "\u30c6\u30a4\u30eb\u30ba \u30aa\u30d6 \u30b6 \u30ef\u30fc\u30eb\u30c9\\n\u30ec\u30fc\u30f4 \u30e6\u30ca\u30a4\u30c6\u30a3\u30a2": [
+    "\u30c6\u30a4\u30eb\u30ba \u30aa\u30d6 \u30b6 \u30ef\u30fc\u30eb\u30c9\n\u30ec\u30fc\u30f4 \u30e6\u30ca\u30a4\u30c6\u30a3\u30a2": [
         "ATUJ"
     ],
     "\u30d7\u30ed\u91ce\u7403 \u30d5\u30a1\u30df\u30b9\u30bf \u30ea\u30bf\u30fc\u30f3\u30ba": [
@@ -3334,40 +3334,40 @@
     "\u9006\u8ee2\u88c1\u5224123\u3000\u6210\u6b69\u5802\u30bb\u30ec\u30af\u30b7\u30e7\u30f3": [
         "BHDJ"
     ],
-    "\u6975\u9650\u8131\u51faADV\\n\u5584\u4eba\u30b7\u30dc\u30a6\u30c7\u30b9": [
+    "\u6975\u9650\u8131\u51faADV\n\u5584\u4eba\u30b7\u30dc\u30a6\u30c7\u30b9": [
         "AKGJ"
     ],
-    "\u30cf\u30de\u30c8\u30e9\\nLook at Smoking World": [
+    "\u30cf\u30de\u30c8\u30e9\nLook at Smoking World": [
         "BATJ"
     ],
-    "\u307e\u3081\u30b4\u30de\\n\u3088\u3044\u3053 \u307e\u308b\u3044\u3053 \u3052\u3093\u304d\u306a\u3053\uff01": [
+    "\u307e\u3081\u30b4\u30de\n\u3088\u3044\u3053 \u307e\u308b\u3044\u3053 \u3052\u3093\u304d\u306a\u3053\uff01": [
         "AM6J"
     ],
-    "\u30d7\u30ea\u30d1\u30e9\\n\u3081\u3056\u3081\u3088!\u5973\u795e\u306e\uff84\uff9e\uff9a\uff7d\uff83\uff9e\uff7b\uff9e\uff72\uff9d": [
+    "\u30d7\u30ea\u30d1\u30e9\n\u3081\u3056\u3081\u3088!\u5973\u795e\u306e\uff84\uff9e\uff9a\uff7d\uff83\uff9e\uff7b\uff9e\uff72\uff9d": [
         "BP7J"
     ],
-    "\u7267\u5834\u7269\u8a9e\\n\u3075\u305f\u3054\u306e\u6751\uff0b": [
+    "\u7267\u5834\u7269\u8a9e\n\u3075\u305f\u3054\u306e\u6751\uff0b": [
         "A22J"
     ],
-    "\u7267\u5834\u7269\u8a9e\\n\u306f\u3058\u307e\u308a\u306e\u5927\u5730": [
+    "\u7267\u5834\u7269\u8a9e\n\u306f\u3058\u307e\u308a\u306e\u5927\u5730": [
         "ABQJ"
     ],
-    "\u7267\u5834\u7269\u8a9e\\n\u3064\u306a\u304c\u308b\u65b0\u5929\u5730": [
+    "\u7267\u5834\u7269\u8a9e\n\u3064\u306a\u304c\u308b\u65b0\u5929\u5730": [
         "BTSJ"
     ],
-    "\u30c9\u30e9\u304b\u305a\\n\u306e\u3073\u592a\u306e\u3059\u3046\u3058\u5927\u5192\u967a": [
+    "\u30c9\u30e9\u304b\u305a\n\u306e\u3073\u592a\u306e\u3059\u3046\u3058\u5927\u5192\u967a": [
         "ADWJ"
     ],
-    "\u7267\u5834\u7269\u8a9e\\n\uff13\u3064\u306e\u91cc\u306e\u5927\u5207\u306a\u53cb\u3060\u3061": [
+    "\u7267\u5834\u7269\u8a9e\n\uff13\u3064\u306e\u91cc\u306e\u5927\u5207\u306a\u53cb\u3060\u3061": [
         "BB3J"
     ],
-    "\u307e\u3081\u30b4\u30de\\n\u306f\u3063\u3074\u30fc\uff01\u30b9\u30a4\u30fc\u30c4\u30d5\u30a1\u30fc\u30e0": [
+    "\u307e\u3081\u30b4\u30de\n\u306f\u3063\u3074\u30fc\uff01\u30b9\u30a4\u30fc\u30c4\u30d5\u30a1\u30fc\u30e0": [
         "AGWJ"
     ],
-    "\u307e\u307b\u30b3\u30ec\\n\u9b54\u6cd5\u2606\u3042\u3044\u3069\u308b\u30b3\u30ec\u30af\u30b7\u30e7\u30f3": [
+    "\u307e\u307b\u30b3\u30ec\n\u9b54\u6cd5\u2606\u3042\u3044\u3069\u308b\u30b3\u30ec\u30af\u30b7\u30e7\u30f3": [
         "BM8J"
     ],
-    "\u30d7\u30ea\u30d1\u30e9\\n\u3081\u3056\u305b\uff01\uff71\uff72\uff84\uff9e\uff99\u2606\uff78\uff9e\uff97\uff9d\uff8c\uff9f\uff98No.1\uff01": [
+    "\u30d7\u30ea\u30d1\u30e9\n\u3081\u3056\u305b\uff01\uff71\uff72\uff84\uff9e\uff99\u2606\uff78\uff9e\uff97\uff9d\uff8c\uff9f\uff98No.1\uff01": [
         "APJJ"
     ],
     "\u307e\u3081\u3057\u3070": [
@@ -3379,25 +3379,25 @@
     "\u95d8\u795e\u90fd\u5e02": [
         "BTTJ"
     ],
-    "\u30c7\u30a3\u30ba\u30cb\u30fc\u00a0\u30a8\u30d4\u30c3\u30af\u30df\u30c3\u30ad\u30fc\uff1a\\n\u30df\u30c3\u30ad\u30fc\u306e\u3075\u3057\u304e\u306a\u5192\u967a": [
+    "\u30c7\u30a3\u30ba\u30cb\u30fc\u00a0\u30a8\u30d4\u30c3\u30af\u30df\u30c3\u30ad\u30fc\uff1a\n\u30df\u30c3\u30ad\u30fc\u306e\u3075\u3057\u304e\u306a\u5192\u967a": [
         "AECJ"
     ],
     "\u5927\u9006\u8ee2\u88c1\u5224 -\u6210\u6b69\u5802\u9f8d\u30ce\u4ecb\u306e\u5192\u96aa-": [
         "BDGJ"
     ],
-    "\u30ef\u30f3\u30d4\u30fc\u30b9 ROMANCE DAWN\\n\u5192\u967a\u306e\u591c\u660e\u3051": [
+    "\u30ef\u30f3\u30d4\u30fc\u30b9 ROMANCE DAWN\n\u5192\u967a\u306e\u591c\u660e\u3051": [
         "BRDJ"
     ],
-    "\u592a\u9f13\u306e\u9054\u4eba \u30c9\u30b3\u30c9\u30f3\uff01\\n\u30df\u30b9\u30c6\u30ea\u30fc\u30a2\u30c9\u30d9\u30f3\u30c1\u30e3\u30fc": [
+    "\u592a\u9f13\u306e\u9054\u4eba \u30c9\u30b3\u30c9\u30f3\uff01\n\u30df\u30b9\u30c6\u30ea\u30fc\u30a2\u30c9\u30d9\u30f3\u30c1\u30e3\u30fc": [
         "BT8J"
     ],
-    "\u8d85\u30fb\u6226\u95d8\u4e2d \u7a76\u6975\u306e\u5fcd\u3068\\n\u30d0\u30c8\u30eb\u30d7\u30ec\u30a4\u30e4\u30fc\u9802\u4e0a\u6c7a\u6226\uff01": [
+    "\u8d85\u30fb\u6226\u95d8\u4e2d \u7a76\u6975\u306e\u5fcd\u3068\n\u30d0\u30c8\u30eb\u30d7\u30ec\u30a4\u30e4\u30fc\u9802\u4e0a\u6c7a\u6226\uff01": [
         "AJSJ"
     ],
-    "\u30e1\u30c0\u30ed\u30c3\u30c8 \u30af\u30e9\u30b7\u30c3\u30af\u30b9\\n\u30ab\u30d6\u30c8Ver.": [
+    "\u30e1\u30c0\u30ed\u30c3\u30c8 \u30af\u30e9\u30b7\u30c3\u30af\u30b9\n\u30ab\u30d6\u30c8Ver.": [
         "BKUJ"
     ],
-    "\u30e1\u30c0\u30ed\u30c3\u30c8 \u30af\u30e9\u30b7\u30c3\u30af\u30b9\\n\u30af\u30ef\u30ac\u30bfVer.": [
+    "\u30e1\u30c0\u30ed\u30c3\u30c8 \u30af\u30e9\u30b7\u30c3\u30af\u30b9\n\u30af\u30ef\u30ac\u30bfVer.": [
         "BKWJ"
     ],
     "\u30ea\u30ba\u30e0\u5929\u56fd \u30b6\u30fb\u30d9\u30b9\u30c8\uff0b": [
@@ -3406,16 +3406,16 @@
     "\u5f31\u866b\u30da\u30c0\u30eb \u660e\u65e5\u3078\u306e\u9ad8\u56de\u8ee2": [
         "AYPJ"
     ],
-    "\u30c9\u30e9\u3048\u3082\u3093 \u306e\u3073\u592a\u3068\u5947\u8de1\u306e\u5cf6\\n\uff5e\u30a2\u30cb\u30de\u30eb \u30a2\u30c9\u30d9\u30f3\u30c1\u30e3\u30fc\uff5e": [
+    "\u30c9\u30e9\u3048\u3082\u3093 \u306e\u3073\u592a\u3068\u5947\u8de1\u306e\u5cf6\n\uff5e\u30a2\u30cb\u30de\u30eb \u30a2\u30c9\u30d9\u30f3\u30c1\u30e3\u30fc\uff5e": [
         "AA2J"
     ],
-    "\u30ad\u30e9\u2605\u30e1\u30ad \u304a\u3057\u3083\u308c\u30b5\u30ed\u30f3\uff01\\n\uff5e\u308f\u305f\u3057\u306e\u3057\u3054\u3068\u306f\u7f8e\u5bb9\u5e2b\u3055\u3093\uff5e": [
+    "\u30ad\u30e9\u2605\u30e1\u30ad \u304a\u3057\u3083\u308c\u30b5\u30ed\u30f3\uff01\n\uff5e\u308f\u305f\u3057\u306e\u3057\u3054\u3068\u306f\u7f8e\u5bb9\u5e2b\u3055\u3093\uff5e": [
         "AATJ"
     ],
     "\u5fc3\u970a\u30ab\u30e1\u30e9 \uff5e\u6191\u3044\u3066\u308b\u624b\u5e33\uff5e": [
         "ALCJ"
     ],
-    "\u30c9\u30e9\u3048\u3082\u3093 \u65b0\u30fb\u306e\u3073\u592a\u306e\u5927\u9b54\u5883\\n\uff5e\u30da\u30b3\u3068\uff15\u4eba\u306e\u63a2\u691c\u968a\uff5e": [
+    "\u30c9\u30e9\u3048\u3082\u3093 \u65b0\u30fb\u306e\u3073\u592a\u306e\u5927\u9b54\u5883\n\uff5e\u30da\u30b3\u3068\uff15\u4eba\u306e\u63a2\u691c\u968a\uff5e": [
         "BNMJ"
     ],
     "\u30c9\u30e9\u3048\u3082\u3093 \u65b0\u30fb\u306e\u3073\u592a\u306e\u65e5\u672c\u8a95\u751f": [
@@ -3430,49 +3430,49 @@
     "\u6d1e\u7a9f\u7269\u8a9e\uff13D": [
         "ACVJ"
     ],
-    "\u30a2\u30a4\u30ab\u30c4\uff01\\n365\u65e5\u306e\u30a2\u30a4\u30c9\u30eb\u30c7\u30a4\u30ba": [
+    "\u30a2\u30a4\u30ab\u30c4\uff01\n365\u65e5\u306e\u30a2\u30a4\u30c9\u30eb\u30c7\u30a4\u30ba": [
         "BA3J"
     ],
-    "\u30a2\u30a4\u30ab\u30c4\uff01\\nMy No.1 Stage!": [
+    "\u30a2\u30a4\u30ab\u30c4\uff01\nMy No.1 Stage!": [
         "AK4J"
     ],
-    "\u4e03\u3064\u306e\u5927\u7f6a\\n\u771f\u5b9f\u306e\u51a4\u7f6a": [
+    "\u4e03\u3064\u306e\u5927\u7f6a\n\u771f\u5b9f\u306e\u51a4\u7f6a": [
         "BS7J"
     ],
-    "\u30c9\u30e9\u3048\u3082\u3093\\n\u306e\u3073\u592a\u306e\u5b9d\u5cf6": [
+    "\u30c9\u30e9\u3048\u3082\u3093\n\u306e\u3073\u592a\u306e\u5b9d\u5cf6": [
         "BNLJ"
     ],
-    "\u30d1\u30ba\u30c9\u30e9\uff3a\\n\u9650\u5b9a\u30c1\u30e3\u30ec\u30f3\u30b8\u7248": [
+    "\u30d1\u30ba\u30c9\u30e9\uff3a\n\u9650\u5b9a\u30c1\u30e3\u30ec\u30f3\u30b8\u7248": [
         "APZJ"
     ],
-    "\u30ef\u30f3\u30d4\u30fc\u30b9\\n\u8d85\u30b0\u30e9\u30f3\u30c9\u30d0\u30c8\u30eb\uff01\uff38": [
+    "\u30ef\u30f3\u30d4\u30fc\u30b9\n\u8d85\u30b0\u30e9\u30f3\u30c9\u30d0\u30c8\u30eb\uff01\uff38": [
         "BG3J"
     ],
-    "\u592a\u9f13\u306e\u9054\u4eba\\n\u3069\u3093\u3068\u304b\u3064\u306e\u6642\u7a7a\u5927\u5192\u967a": [
+    "\u592a\u9f13\u306e\u9054\u4eba\n\u3069\u3093\u3068\u304b\u3064\u306e\u6642\u7a7a\u5927\u5192\u967a": [
         "BT7J"
     ],
-    "\u30c9\u30e9\u3048\u3082\u3093\\n\u306e\u3073\u592a\u306e\u3072\u307f\u3064\u9053\u5177\u535a\u7269\u9928": [
+    "\u30c9\u30e9\u3048\u3082\u3093\n\u306e\u3073\u592a\u306e\u3072\u307f\u3064\u9053\u5177\u535a\u7269\u9928": [
         "AD9J"
     ],
-    "\u30ef\u30f3\u30d4\u30fc\u30b9\\n\u30a2\u30f3\u30ea\u30df\u30c6\u30c3\u30c9\u30af\u30eb\u30fc\u30ba\uff33\uff30": [
+    "\u30ef\u30f3\u30d4\u30fc\u30b9\n\u30a2\u30f3\u30ea\u30df\u30c6\u30c3\u30c9\u30af\u30eb\u30fc\u30ba\uff33\uff30": [
         "ALFJ"
     ],
-    "\u30d1\u30ba\u30c9\u30e9\uff3a\\n\u30b3\u30ed\u30b3\u30ed\u30b3\u30df\u30c3\u30af\u9650\u5b9a\u4f53\u9a13\u7248": [
+    "\u30d1\u30ba\u30c9\u30e9\uff3a\n\u30b3\u30ed\u30b3\u30ed\u30b3\u30df\u30c3\u30af\u9650\u5b9a\u4f53\u9a13\u7248": [
         "ANFJ"
     ],
-    "\u30c9\u30e9\u3048\u3082\u3093\\n\u306e\u3073\u592a\u306e\u5357\u6975\u30ab\u30c1\u30b3\u30c1\u5927\u5192\u967a": [
+    "\u30c9\u30e9\u3048\u3082\u3093\n\u306e\u3073\u592a\u306e\u5357\u6975\u30ab\u30c1\u30b3\u30c1\u5927\u5192\u967a": [
         "BDUJ"
     ],
-    "\u8d85\u30fb\u9003\u8d70\u4e2d\\n\u3042\u3064\u307e\u308c\uff01\u6700\u5f37\u306e\u9003\u8d70\u8005\u305f\u3061": [
+    "\u8d85\u30fb\u9003\u8d70\u4e2d\n\u3042\u3064\u307e\u308c\uff01\u6700\u5f37\u306e\u9003\u8d70\u8005\u305f\u3061": [
         "BTUJ"
     ],
-    "\u592a\u9f13\u306e\u9054\u4eba\\n\u3061\u3073\u30c9\u30e9\u30b4\u30f3\u3068\u4e0d\u601d\u8b70\u306a\u30aa\u30fc\u30d6": [
+    "\u592a\u9f13\u306e\u9054\u4eba\n\u3061\u3073\u30c9\u30e9\u30b4\u30f3\u3068\u4e0d\u601d\u8b70\u306a\u30aa\u30fc\u30d6": [
         "ATDJ"
     ],
-    "\u3054\u5f53\u5730\u9244\u9053\\n\uff5e\u3054\u5f53\u5730\u30ad\u30e3\u30e9\u3068\u65e5\u672c\u5168\u56fd\u306e\u65c5\uff5e": [
+    "\u3054\u5f53\u5730\u9244\u9053\n\uff5e\u3054\u5f53\u5730\u30ad\u30e3\u30e9\u3068\u65e5\u672c\u5168\u56fd\u306e\u65c5\uff5e": [
         "BLTJ"
     ],
-    "\u30cd\u30b3\u30fb\u30c8\u30e2\\n\u307b\u3093\u308f\u304b\u5bb6\u65cf\u304c\u3067\u304d\u3061\u3083\u3046\u30b2\u30fc\u30e0": [
+    "\u30cd\u30b3\u30fb\u30c8\u30e2\n\u307b\u3093\u308f\u304b\u5bb6\u65cf\u304c\u3067\u304d\u3061\u3083\u3046\u30b2\u30fc\u30e0": [
         "BNFJ"
     ],
     "\u9006\u8ee2\u88c1\u5224\uff15": [
@@ -3487,7 +3487,7 @@
     "\u30b7\u30a2\u30c8\u30ea\u30ba\u30e0 FF \u30ab\u30fc\u30c6\u30f3\u30b3\u30fc\u30eb": [
         "BTHJ"
     ],
-    "\u304a\u3055\u308f\u308a\u63a2\u5075 \u5c0f\u6ca2\u91cc\u5948 \u30e9\u30a4\u30b8\u30f3\u30b0\uff13\\n\u306a\u3081\u3053\u306f\u30d0\u30ca\u30ca\u306e\u5922\u3092\u898b\u308b\u304b\uff1f": [
+    "\u304a\u3055\u308f\u308a\u63a2\u5075 \u5c0f\u6ca2\u91cc\u5948 \u30e9\u30a4\u30b8\u30f3\u30b0\uff13\n\u306a\u3081\u3053\u306f\u30d0\u30ca\u30ca\u306e\u5922\u3092\u898b\u308b\u304b\uff1f": [
         "AN7J"
     ],
     "\u30cf\u30b3\u30dc\u30fc\u30a4\uff01 \u30cf\u30b3\u3065\u3081\uff22\uff2f\uff38": [
@@ -3503,40 +3503,40 @@
         "AN4J",
         "AN4Z"
     ],
-    "\uff8c\uff9f\uff98\uff8a\uff9f\uff97&\uff8c\uff9f\uff98\uff83\uff68\uff70\uff98\uff7d\uff9e\uff91 \uff8c\uff9f\uff98\uff8a\uff9f\uff97\u3067\\n\u3064\u304b\u3048\u308b\u304a\u3057\u3083\u308c\uff71\uff72\uff83\uff911450!": [
+    "\uff8c\uff9f\uff98\uff8a\uff9f\uff97&\uff8c\uff9f\uff98\uff83\uff68\uff70\uff98\uff7d\uff9e\uff91 \uff8c\uff9f\uff98\uff8a\uff9f\uff97\u3067\n\u3064\u304b\u3048\u308b\u304a\u3057\u3083\u308c\uff71\uff72\uff83\uff911450!": [
         "BPAJ"
     ],
     "\u304b\u308f\u3044\u3044\u4ed4\u72ac3D": [
         "ACTJ"
     ],
-    "\u3053\u3073\u3068\u3065\u304b\u3093\\n\u3053\u3073\u3068\u306e\u4e0d\u601d\u8b70 \u5b9f\u9a13\u30bb\u30c3\u30c8": [
+    "\u3053\u3073\u3068\u3065\u304b\u3093\n\u3053\u3073\u3068\u306e\u4e0d\u601d\u8b70 \u5b9f\u9a13\u30bb\u30c3\u30c8": [
         "BK2J"
     ],
-    "\u9ed2\u5b50\u306e\u30d0\u30b9\u30b1\\n\u672a\u6765\u3078\u306e\u30ad\u30ba\u30ca": [
+    "\u9ed2\u5b50\u306e\u30d0\u30b9\u30b1\n\u672a\u6765\u3078\u306e\u30ad\u30ba\u30ca": [
         "AK5J"
     ],
-    "\u9ed2\u5b50\u306e\u30d0\u30b9\u30b1\\n\u52dd\u5229\u3078\u306e\u30ad\u30bb\u30ad": [
+    "\u9ed2\u5b50\u306e\u30d0\u30b9\u30b1\n\u52dd\u5229\u3078\u306e\u30ad\u30bb\u30ad": [
         "BASJ"
     ],
-    "\u3053\u3073\u3068\u3065\u304b\u3093\\n\u3053\u3073\u3068\u89b3\u5bdf\u30bb\u30c3\u30c8": [
+    "\u3053\u3073\u3068\u3065\u304b\u3093\n\u3053\u3073\u3068\u89b3\u5bdf\u30bb\u30c3\u30c8": [
         "AKVJ"
     ],
-    "\u30d9\u30a4\u30de\u30c3\u30af\u30b9\\n\u30d2\u30fc\u30ed\u30fc\u30ba\u30d0\u30c8\u30eb": [
+    "\u30d9\u30a4\u30de\u30c3\u30af\u30b9\n\u30d2\u30fc\u30ed\u30fc\u30ba\u30d0\u30c8\u30eb": [
         "BH6J"
     ],
-    "\u30e2\u30f3\u30cf\u30f3\u65e5\u8a18\\n\u307d\u304b\u307d\u304b\u30a2\u30a4\u30eb\u30fc\u6751DX": [
+    "\u30e2\u30f3\u30cf\u30f3\u65e5\u8a18\n\u307d\u304b\u307d\u304b\u30a2\u30a4\u30eb\u30fc\u6751DX": [
         "BARJ"
     ],
-    "\u5927\u9006\u8ee2\u88c1\u5224\uff12\\n\u2015\u6210\u6b69\u5802\u9f8d\u30ce\u4ecb\u306e\u89ba\u609f\u2015": [
+    "\u5927\u9006\u8ee2\u88c1\u5224\uff12\n\u2015\u6210\u6b69\u5802\u9f8d\u30ce\u4ecb\u306e\u89ba\u609f\u2015": [
         "AJ2J"
     ],
-    "\u30b7\u30a2\u30c8\u30ea\u30ba\u30e0\\n\u30d5\u30a1\u30a4\u30ca\u30eb\u30d5\u30a1\u30f3\u30bf\u30b8\u30fc": [
+    "\u30b7\u30a2\u30c8\u30ea\u30ba\u30e0\n\u30d5\u30a1\u30a4\u30ca\u30eb\u30d5\u30a1\u30f3\u30bf\u30b8\u30fc": [
         "ATHJ"
     ],
-    "\u305f\u307e\u3054\u3063\u3061\u306e\\n\u30c9\u30ad\u30c9\u30ad\u2606\u30c9\u30ea\u30fc\u30e0\u304a\u307f\u305b\u3063\u3061": [
+    "\u305f\u307e\u3054\u3063\u3061\u306e\n\u30c9\u30ad\u30c9\u30ad\u2606\u30c9\u30ea\u30fc\u30e0\u304a\u307f\u305b\u3063\u3061": [
         "AT8J"
     ],
-    "\u305f\u307e\u3054\u3063\u3061\uff01\\n\u305b\u30fc\u3057\u3085\u3093\u306e\u30c9\u30ea\u30fc\u30e0\u30b9\u30af\u30fc\u30eb": [
+    "\u305f\u307e\u3054\u3063\u3061\uff01\n\u305b\u30fc\u3057\u3085\u3093\u306e\u30c9\u30ea\u30fc\u30e0\u30b9\u30af\u30fc\u30eb": [
         "BD6J"
     ],
     "\u3061\u3073\u2606\u30c7\u30d3\uff01": [
@@ -3545,7 +3545,7 @@
     "\u3077\u3088\u3077\u3088\uff01\uff01": [
         "AP2J"
     ],
-    "\u30a2\u30a4\u30c9\u30eb\u30bf\u30a4\u30e0 \u30d7\u30ea\u30d1\u30e9\\n\u5922\u30aa\u30fc\u30eb\u30b9\u30bf\u30fc\u30e9\u30a4\u30d6\uff01": [
+    "\u30a2\u30a4\u30c9\u30eb\u30bf\u30a4\u30e0 \u30d7\u30ea\u30d1\u30e9\n\u5922\u30aa\u30fc\u30eb\u30b9\u30bf\u30fc\u30e9\u30a4\u30d6\uff01": [
         "B2PJ"
     ],
     "\u30c0\u30f3\u30dc\u30fc\u30eb\u6226\u6a5f \u7206\u30d6\u30fc\u30b9\u30c8": [
@@ -3572,40 +3572,40 @@
     "\u30c0\u30f3\u30dc\u30fc\u30eb\u6226\u6a5fW \u8d85\u30ab\u30b9\u30bf\u30e0": [
         "BDWJ"
     ],
-    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30ebZ\\n\u8d85\u7a76\u6975\u6b66\u95d8\u4f1d": [
+    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30ebZ\n\u8d85\u7a76\u6975\u6b66\u95d8\u4f1d": [
         "BDVJ"
     ],
-    "\u63a2\u5075\u795e\u5bae\u5bfa\u4e09\u90ce\\nGHOST OF THE DUSK": [
+    "\u63a2\u5075\u795e\u5bae\u5bfa\u4e09\u90ce\nGHOST OF THE DUSK": [
         "BG9J"
     ],
-    "\u4e16\u754c\u6a39\u306e\u8ff7\u5bae\u2163\\n\u4f1d\u627f\u306e\u5de8\u795e": [
+    "\u4e16\u754c\u6a39\u306e\u8ff7\u5bae\u2163\n\u4f1d\u627f\u306e\u5de8\u795e": [
         "ASJJ"
     ],
-    "\u30da\u30f3\u30ae\u30f3\u306e\u554f\u984c\\n\u30b6\u30fb\u30a6\u30a9\u30fc\u30ba": [
+    "\u30da\u30f3\u30ae\u30f3\u306e\u554f\u984c\n\u30b6\u30fb\u30a6\u30a9\u30fc\u30ba": [
         "AP5J"
     ],
-    "\u30ec\u30a4\u30c8\u30f3\u6559\u6388\u3068\\n\u8d85\u6587\u660e\uff21\u306e\u907a\u7523": [
+    "\u30ec\u30a4\u30c8\u30f3\u6559\u6388\u3068\n\u8d85\u6587\u660e\uff21\u306e\u907a\u7523": [
         "AL6J"
     ],
-    "\u96e3\u653b\u4e0d\u843d\u4e09\u56fd\u4f1d\\n\uff5e\u8700\u3068\u6642\u306e\u9285\u96c0\uff5e": [
+    "\u96e3\u653b\u4e0d\u843d\u4e09\u56fd\u4f1d\n\uff5e\u8700\u3068\u6642\u306e\u9285\u96c0\uff5e": [
         "BSDJ"
     ],
-    "\u6589\u6728\u6960\u96c4\u306e\u03a8\u96e3\\n\u53f2\u4e0a\u03a8\u5927\u306e\u03a8\u96e3\uff01\uff1f": [
+    "\u6589\u6728\u6960\u96c4\u306e\u03a8\u96e3\n\u53f2\u4e0a\u03a8\u5927\u306e\u03a8\u96e3\uff01\uff1f": [
         "AKAJ"
     ],
-    "\u30e9\u30f3\u30b0\u30ea\u30c3\u30b5\u30fc\\n\u30ea\u30a4\u30f3\u30ab\u30fc\u30cd\u30fc\u30b7\u30e7\u30f3 -\u8ee2\u751f-": [
+    "\u30e9\u30f3\u30b0\u30ea\u30c3\u30b5\u30fc\n\u30ea\u30a4\u30f3\u30ab\u30fc\u30cd\u30fc\u30b7\u30e7\u30f3 -\u8ee2\u751f-": [
         "BRGJ"
     ],
-    "\u3061\u3073\u2606\u30c7\u30d3\uff01\uff12\\n\uff5e\u9b54\u6cd5\u306e\u3086\u3081\u3048\u307b\u3093\uff5e": [
+    "\u3061\u3073\u2606\u30c7\u30d3\uff01\uff12\n\uff5e\u9b54\u6cd5\u306e\u3086\u3081\u3048\u307b\u3093\uff5e": [
         "ADSJ"
     ],
-    "\u30af\u30c3\u30ad\u30f3\u30b0\u30de\u30de\\n\u308f\u305f\u3057\u306e\u30b9\u30a4\u30fc\u30c4\u30b7\u30e7\u30c3\u30d7": [
+    "\u30af\u30c3\u30ad\u30f3\u30b0\u30de\u30de\n\u308f\u305f\u3057\u306e\u30b9\u30a4\u30fc\u30c4\u30b7\u30e7\u30c3\u30d7": [
         "BS8J"
     ],
-    "\u602a\u76d7\u30b8\u30e7\u30fc\u30ab\u30fc\\n\u6642\u3092\u8d85\u3048\u308b\u602a\u76d7\u3068\u5931\u308f\u308c\u305f\u5b9d\u77f3": [
+    "\u602a\u76d7\u30b8\u30e7\u30fc\u30ab\u30fc\n\u6642\u3092\u8d85\u3048\u308b\u602a\u76d7\u3068\u5931\u308f\u308c\u305f\u5b9d\u77f3": [
         "AKJJ"
     ],
-    "\u3061\u3087\uff5e\u308a\u3063\u3061\uff01\\n\u305f\u307e\u3054\u3063\u3061\u306e\u30d7\u30c1\u30d7\u30c1\u304a\u307f\u305b\u3063\u3061": [
+    "\u3061\u3087\uff5e\u308a\u3063\u3061\uff01\n\u305f\u307e\u3054\u3063\u3061\u306e\u30d7\u30c1\u30d7\u30c1\u304a\u307f\u305b\u3063\u3061": [
         "AT5J"
     ],
     "\u30de\u30ea\u30aa\u30ab\u30fc\u30c8\uff17": [
@@ -3621,82 +3621,82 @@
     "\u30c8\u30e9\u30a4\u30d6\u30af\u30eb\u30af\u30eb THE G@ME": [
         "BQRJ"
     ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u7fbd\u7530 ALL STARS": [
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u7fbd\u7530 ALL STARS": [
         "BKAJ"
     ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u6210\u7530 ALL STARS": [
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u6210\u7530 ALL STARS": [
         "BNAJ"
     ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u95a2\u7a7a ALL STARS": [
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u95a2\u7a7a ALL STARS": [
         "BPKJ"
     ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u90a3\u8987 PREMIUM": [
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u90a3\u8987 PREMIUM": [
         "AX5J"
     ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u95a2\u7a7a SKY STORY": [
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u95a2\u7a7a SKY STORY": [
         "AKXJ"
     ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u7fbd\u7530 with \uff2a\uff21\uff2c": [
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u7fbd\u7530 with \uff2a\uff21\uff2c": [
         "AH7J"
     ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u6210\u7530 with \uff21\uff2e\uff21": [
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u6210\u7530 with \uff21\uff2e\uff21": [
         "AN6J"
     ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u65b0\u5343\u6b73 with \uff2a\uff21\uff2c": [
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u65b0\u5343\u6b73 with \uff2a\uff21\uff2c": [
         "BBKJ"
     ],
-    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u30db\u30ce\u30eb\u30eb": [
+    "\u307c\u304f\u306f\u822a\u7a7a\u7ba1\u5236\u5b98 \u30a8\u30a2\u30dd\u30fc\u30c8\n\u30d2\u30fc\u30ed\u30fc\uff13\uff24 \u30db\u30ce\u30eb\u30eb": [
         "AHWJ"
     ],
-    "\u30aa\u30ec\u69d8\u30ad\u30f3\u30b0\u30c0\u30e0 \uff72\uff79\uff92\uff9d\u5f7c\u6c0f\u3092\\n\uff79\uff9e\uff6f\uff84\u3057\u3088\uff01\u3082\u3048\uff77\uff6d\uff9d\u2665\uff7d\uff78\uff70\uff99\uff83\uff9e\uff72\uff7d\uff9e": [
+    "\u30aa\u30ec\u69d8\u30ad\u30f3\u30b0\u30c0\u30e0 \uff72\uff79\uff92\uff9d\u5f7c\u6c0f\u3092\n\uff79\uff9e\uff6f\uff84\u3057\u3088\uff01\u3082\u3048\uff77\uff6d\uff9d\u2665\uff7d\uff78\uff70\uff99\uff83\uff9e\uff72\uff7d\uff9e": [
         "AK7J"
     ],
     "\u30c7\u30d3\u30eb\u30b5\u30d0\u30a4\u30d0\u30fc \u30aa\u30fc\u30d0\u30fc\u30af\u30ed\u30c3\u30af": [
         "ADVJ"
     ],
-    "\u30c7\u30d3\u30eb\u30b5\u30d0\u30a4\u30d0\u30fc2\\n\u30d6\u30ec\u30a4\u30af\u30ec\u30b3\u30fc\u30c9": [
+    "\u30c7\u30d3\u30eb\u30b5\u30d0\u30a4\u30d0\u30fc2\n\u30d6\u30ec\u30a4\u30af\u30ec\u30b3\u30fc\u30c9": [
         "ADXJ"
     ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO2\\n\u30af\u30ed\u30ce\u30fb\u30b9\u30c8\u30fc\u30f3 \"\u30cd\u30c3\u30d7\u30a6\"": [
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO2\n\u30af\u30ed\u30ce\u30fb\u30b9\u30c8\u30fc\u30f3 \"\u30cd\u30c3\u30d7\u30a6\"": [
         "ANPJ"
     ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO2\\n\u30af\u30ed\u30ce\u30fb\u30b9\u30c8\u30fc\u30f3 \"\u30e9\u30a4\u30e1\u30a4\"": [
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO2\n\u30af\u30ed\u30ce\u30fb\u30b9\u30c8\u30fc\u30f3 \"\u30e9\u30a4\u30e1\u30a4\"": [
         "ARAJ"
     ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\\n\u30c0\u30fc\u30af": [
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\n\u30c0\u30fc\u30af": [
         "AEDJ"
     ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\\n\u30b7\u30e3\u30a4\u30f3": [
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\n\u30b7\u30e3\u30a4\u30f3": [
         "AE4J"
     ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\\n\u30ae\u30e3\u30e9\u30af\u30b7\u30fc \u30d3\u30c3\u30b0\u30d0\u30f3": [
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\n\u30ae\u30e3\u30e9\u30af\u30b7\u30fc \u30d3\u30c3\u30b0\u30d0\u30f3": [
         "BGVJ"
     ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\\n\u30ae\u30e3\u30e9\u30af\u30b7\u30fc \u30b9\u30fc\u30d1\u30fc\u30ce\u30f4\u30a1": [
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3GO\n\u30ae\u30e3\u30e9\u30af\u30b7\u30fc \u30b9\u30fc\u30d1\u30fc\u30ce\u30f4\u30a1": [
         "BGSJ"
     ],
-    "\u30c7\u30b8\u30e2\u30f3\u30ef\u30fc\u30eb\u30c9\\nRe:Digitize Decode": [
+    "\u30c7\u30b8\u30e2\u30f3\u30ef\u30fc\u30eb\u30c9\nRe:Digitize Decode": [
         "ADJJ"
     ],
-    "\u30de\u30ea\u30aa\uff06\u30bd\u30cb\u30c3\u30af\\n\uff21\uff34 \u30ed\u30f3\u30c9\u30f3\u30aa\u30ea\u30f3\u30d4\u30c3\u30af": [
+    "\u30de\u30ea\u30aa\uff06\u30bd\u30cb\u30c3\u30af\n\uff21\uff34 \u30ed\u30f3\u30c9\u30f3\u30aa\u30ea\u30f3\u30d4\u30c3\u30af": [
         "ACMJ"
     ],
-    "\u30a2\u30af\u30ea\u30eb\u30d1\u30ec\u30c3\u30c8\\n\uff5e\u5f69\u308a\u30ab\u30d5\u30a7\u30fbCheers\uff5e": [
+    "\u30a2\u30af\u30ea\u30eb\u30d1\u30ec\u30c3\u30c8\n\uff5e\u5f69\u308a\u30ab\u30d5\u30a7\u30fbCheers\uff5e": [
         "AYDJ"
     ],
-    "\u30e9\u30f3\u30ca\u30d0\u30a6\u30c8\uff13\uff24\\n\u30c9\u30e9\u30a4\u30d6\uff1a\u30a4\u30f3\u30dd\u30c3\u30b7\u30d6\u30eb": [
+    "\u30e9\u30f3\u30ca\u30d0\u30a6\u30c8\uff13\uff24\n\u30c9\u30e9\u30a4\u30d6\uff1a\u30a4\u30f3\u30dd\u30c3\u30b7\u30d6\u30eb": [
         "ARNJ"
     ],
-    "\u68a8\u6c41\u30a2\u30af\u30b7\u30e7\u30f3\uff01\\n\u3075\u306a\u3063\u3057\u30fc\u306e\u6109\u5feb\u306a\u304a\u306f\u306a\u3063\u3057\u30fc": [
+    "\u68a8\u6c41\u30a2\u30af\u30b7\u30e7\u30f3\uff01\n\u3075\u306a\u3063\u3057\u30fc\u306e\u6109\u5feb\u306a\u304a\u306f\u306a\u3063\u3057\u30fc": [
         "BFCJ"
     ],
-    "\u65b0\u30c6\u30cb\u30b9\u306e\u738b\u5b50\u69d8\\n\uff5e\uff27\uff4f\u3000\uff54\uff4f\u3000\uff54\uff48\uff45\u3000\uff54\uff4f\uff50\uff5e": [
+    "\u65b0\u30c6\u30cb\u30b9\u306e\u738b\u5b50\u69d8\n\uff5e\uff27\uff4f\u3000\uff54\uff4f\u3000\uff54\uff48\uff45\u3000\uff54\uff4f\uff50\uff5e": [
         "BTPJ"
     ],
-    "\uff4e\uff49\uff43\uff4f\uff4c\uff41\u76e3\u4fee\\n\u30e2\u30c7\u30eb\u2606\u304a\u3057\u3083\u308c\u30aa\u30fc\u30c7\u30a3\u30b7\u30e7\u30f3\uff12": [
+    "\uff4e\uff49\uff43\uff4f\uff4c\uff41\u76e3\u4fee\n\u30e2\u30c7\u30eb\u2606\u304a\u3057\u3083\u308c\u30aa\u30fc\u30c7\u30a3\u30b7\u30e7\u30f3\uff12": [
         "ANLJ"
     ],
-    "\u30d7\u30ea\u30c6\u30a3\u30fc\u30ea\u30ba\u30e0\\n\u30de\u30a4\u2606\u30c7\u30b3\u30ec\u30a4\u30f3\u30dc\u30fc\u30a6\u30a8\u30c7\u30a3\u30f3\u30b0": [
+    "\u30d7\u30ea\u30c6\u30a3\u30fc\u30ea\u30ba\u30e0\n\u30de\u30a4\u2606\u30c7\u30b3\u30ec\u30a4\u30f3\u30dc\u30fc\u30a6\u30a8\u30c7\u30a3\u30f3\u30b0": [
         "APTJ"
     ],
     "\u30af\u30c3\u30ad\u30f3\u30b0\u30de\u30de\uff14": [
@@ -3735,43 +3735,43 @@
     "\u4e21\u76ee\u3067\u53f3\u8133\u3092\u935b\u3048\u308b \uff13\uff24\u901f\u8aad\u8853": [
         "ASKJ"
     ],
-    "\u30c7\u30a3\u30b9\u30af\u2022\u30a6\u30a9\u30fc\u30ba:\u30a2\u30d9\u30f3\u30b8\u30e3\u30fc\u30ba\\n\u30a2\u30eb\u30c6\u30a3\u30e1\u30c3\u30c8\u30d2\u30fc\u30ed\u30fc\u30ba": [
+    "\u30c7\u30a3\u30b9\u30af\u2022\u30a6\u30a9\u30fc\u30ba:\u30a2\u30d9\u30f3\u30b8\u30e3\u30fc\u30ba\n\u30a2\u30eb\u30c6\u30a3\u30e1\u30c3\u30c8\u30d2\u30fc\u30ed\u30fc\u30ba": [
         "AVNJ"
     ],
     "\u30a6\u30a4\u30eb\u30b9\u30b7\u30e5\u30fc\u30bf\u30fcXX": [
         "AV4J"
     ],
-    "\u30ed\u30b9\u30c8\u30d2\u30fc\u30ed\u30fc\u30ba\uff12\\nPREMIUM EDITION": [
+    "\u30ed\u30b9\u30c8\u30d2\u30fc\u30ed\u30fc\u30ba\uff12\nPREMIUM EDITION": [
         "BL3J"
     ],
-    "\u30af\u30ec\u30e8\u30f3\u3057\u3093\u3061\u3083\u3093\\n\u5b87\u5b99DE\u30a2\u30c1\u30e7\u30fc!?": [
+    "\u30af\u30ec\u30e8\u30f3\u3057\u3093\u3061\u3083\u3093\n\u5b87\u5b99DE\u30a2\u30c1\u30e7\u30fc!?": [
         "ACHJ"
     ],
-    "\u30c7\u30b8\u30e2\u30f3\u30e6\u30cb\u30d0\u30fc\u30b9\\n\u30a2\u30d7\u30ea\u30e2\u30f3\u30b9\u30bf\u30fc\u30ba": [
+    "\u30c7\u30b8\u30e2\u30f3\u30e6\u30cb\u30d0\u30fc\u30b9\n\u30a2\u30d7\u30ea\u30e2\u30f3\u30b9\u30bf\u30fc\u30ba": [
         "AUDJ"
     ],
-    "\u6226\u95d8\u4e2d\u3000\u4f1d\u8aac\u306e\u5fcd\u3068\\n\u30b5\u30d0\u30a4\u30d0\u30eb\u30d0\u30c8\u30eb\uff01": [
+    "\u6226\u95d8\u4e2d\u3000\u4f1d\u8aac\u306e\u5fcd\u3068\n\u30b5\u30d0\u30a4\u30d0\u30eb\u30d0\u30c8\u30eb\uff01": [
         "BCBJ"
     ],
-    "\u30a2\u30a4\u30ab\u30c4\u30b9\u30bf\u30fc\u30ba\uff01\\n\uff2d\uff59\u30b9\u30da\u30b7\u30e3\u30eb\u30a2\u30d4\u30fc\u30eb": [
+    "\u30a2\u30a4\u30ab\u30c4\u30b9\u30bf\u30fc\u30ba\uff01\n\uff2d\uff59\u30b9\u30da\u30b7\u30e3\u30eb\u30a2\u30d4\u30fc\u30eb": [
         "AKFJ"
     ],
-    "\u6843\u592a\u90ce\u96fb\u9244\uff12\uff10\uff11\uff17\\n\uff5e\u305f\u3061\u3042\u304c\u308c\u65e5\u672c\uff01\uff01\uff5e": [
+    "\u6843\u592a\u90ce\u96fb\u9244\uff12\uff10\uff11\uff17\n\uff5e\u305f\u3061\u3042\u304c\u308c\u65e5\u672c\uff01\uff01\uff5e": [
         "AKQJ"
     ],
-    "\u5fcd\u8005\u3058\u3083\u3058\u3083\u4e38\u304f\u3093\\n\u3055\u304f\u3089\u59eb\u3068\u706b\u7adc\u306e\u3072\u307f\u3064": [
+    "\u5fcd\u8005\u3058\u3083\u3058\u3083\u4e38\u304f\u3093\n\u3055\u304f\u3089\u59eb\u3068\u706b\u7adc\u306e\u3072\u307f\u3064": [
         "ANNJ"
     ],
-    "\u30aa\u30fc\u30eb\u4eee\u9762\u30e9\u30a4\u30c0\u30fc\\n\u30e9\u30a4\u30c0\u30fc\u30ec\u30dc\u30ea\u30e5\u30fc\u30b7\u30e7\u30f3": [
+    "\u30aa\u30fc\u30eb\u4eee\u9762\u30e9\u30a4\u30c0\u30fc\n\u30e9\u30a4\u30c0\u30fc\u30ec\u30dc\u30ea\u30e5\u30fc\u30b7\u30e7\u30f3": [
         "ARUJ"
     ],
-    "\u9003\u8d70\u4e2d\u3000\u53f2\u4e0a\u6700\u5f37\u306e\\n\u30cf\u30f3\u30bf\u30fc\u305f\u3061\u304b\u3089\u306b\u3052\u304d\u308c\uff01": [
+    "\u9003\u8d70\u4e2d\u3000\u53f2\u4e0a\u6700\u5f37\u306e\n\u30cf\u30f3\u30bf\u30fc\u305f\u3061\u304b\u3089\u306b\u3052\u304d\u308c\uff01": [
         "ATCJ"
     ],
-    "\u30af\u30ec\u30e8\u30f3\u3057\u3093\u3061\u3083\u3093\\n\u6fc0\u30a2\u30c4\uff01\u304a\u3067\u3093\u308f\uff5e\u308b\u3069\u5927\u30b3\u30f3\u4e71!!": [
+    "\u30af\u30ec\u30e8\u30f3\u3057\u3093\u3061\u3083\u3093\n\u6fc0\u30a2\u30c4\uff01\u304a\u3067\u3093\u308f\uff5e\u308b\u3069\u5927\u30b3\u30f3\u4e71!!": [
         "BWKJ"
     ],
-    "\u30af\u30ec\u30e8\u30f3\u3057\u3093\u3061\u3083\u3093\\n\u5d50\u3092\u547c\u3076\u3000\u30ab\u30b9\u30ab\u30d9\u6620\u753b\u30b9\u30bf\u30fc\u30ba\uff01": [
+    "\u30af\u30ec\u30e8\u30f3\u3057\u3093\u3061\u3083\u3093\n\u5d50\u3092\u547c\u3076\u3000\u30ab\u30b9\u30ab\u30d9\u6620\u753b\u30b9\u30bf\u30fc\u30ba\uff01": [
         "BGBJ"
     ],
     "\u6226\u56fd\u7121\u53cc\u30af\u30ed\u30cb\u30af\u30eb": [
@@ -3786,10 +3786,10 @@
     "\u30ed\u30b9\u30c8\u30d2\u30fc\u30ed\u30fc\u30ba\uff12": [
         "BL2J"
     ],
-    "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0 if\\n\u767d\u591c\u738b\u56fd": [
+    "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0 if\n\u767d\u591c\u738b\u56fd": [
         "BFXJ"
     ],
-    "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0 if\\n\u6697\u591c\u738b\u56fd": [
+    "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0 if\n\u6697\u591c\u738b\u56fd": [
         "BFYJ"
     ],
     "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0 if": [
@@ -3801,7 +3801,7 @@
     "\u30a2\u30f3\u30c1\u30a7\u30a4\u30f3\u30d6\u30ec\u30a4\u30ba \u30a8\u30af\u30b7\u30f4": [
         "AUXJ"
     ],
-    "\u5b9f\u6cc1\u30d1\u30ef\u30d5\u30eb\u30d7\u30ed\u91ce\u7403 \u30d2\u30fc\u30ed\u30fc\u30ba\\n\u3010\u4f53\u9a13\u7248\u3011": [
+    "\u5b9f\u6cc1\u30d1\u30ef\u30d5\u30eb\u30d7\u30ed\u91ce\u7403 \u30d2\u30fc\u30ed\u30fc\u30ba\n\u3010\u4f53\u9a13\u7248\u3011": [
         "AWYJ"
     ],
     "\u5b9f\u6cc1\u30d1\u30ef\u30d5\u30eb\u30d7\u30ed\u91ce\u7403 \u30d2\u30fc\u30ed\u30fc\u30ba": [
@@ -3810,43 +3810,43 @@
     "\u30ac\u30f3\u30c0\u30e0\u30c8\u30e9\u30a4\u30a8\u30a4\u30b8SP": [
         "BTAJ"
     ],
-    "\u30ca\u30ca\u30df\u3068\u4e00\u7dd2\u306b\u5b66\u307c\uff01\\nEnglish\u4e0a\u9054\u306e\u30b3\u30c4": [
+    "\u30ca\u30ca\u30df\u3068\u4e00\u7dd2\u306b\u5b66\u307c\uff01\nEnglish\u4e0a\u9054\u306e\u30b3\u30c4": [
         "AYVJ"
     ],
-    "\u308f\u304c\u307e\u307e\u30d5\u30a1\u30c3\u30b7\u30e7\u30f3\\nGIRLS MODE\u3000\u3088\u304f\u3070\u308a\u5ba3\u8a00\uff01": [
+    "\u308f\u304c\u307e\u307e\u30d5\u30a1\u30c3\u30b7\u30e7\u30f3\nGIRLS MODE\u3000\u3088\u304f\u3070\u308a\u5ba3\u8a00\uff01": [
         "ACLJ"
     ],
-    "\u3067\u3093\u3062\u3083\u3089\u3059\u3058\u30fc\u3055\u3093\\n\u30681000\u4eba\u306e\u304a\u53cb\u3060\u3061\u90aa": [
+    "\u3067\u3093\u3062\u3083\u3089\u3059\u3058\u30fc\u3055\u3093\n\u30681000\u4eba\u306e\u304a\u53cb\u3060\u3061\u90aa": [
         "ADZJ"
     ],
-    "\u30b9\u30fc\u30d1\u30fc\u30d6\u30e9\u30c3\u30af\u30d0\u30b9\\n\uff13\uff24\u30d5\u30a1\u30a4\u30c8": [
+    "\u30b9\u30fc\u30d1\u30fc\u30d6\u30e9\u30c3\u30af\u30d0\u30b9\n\uff13\uff24\u30d5\u30a1\u30a4\u30c8": [
         "ASBJ"
     ],
-    "\u30d3\u30c3\u30af\u30ea\u30de\u30f3\u6f22\u719f\u8987\u738b\\n\u4e09\u4f4d\u52d5\u4e71\u6226\u5275\u7d00": [
+    "\u30d3\u30c3\u30af\u30ea\u30de\u30f3\u6f22\u719f\u8987\u738b\n\u4e09\u4f4d\u52d5\u4e71\u6226\u5275\u7d00": [
         "AB9J"
     ],
-    "\u3046\u3057\u307f\u3064\u30e2\u30f3\u30b9\u30c8\u30eb\u30aa\\n\u30ea\u30f3\u30bc\u3068\u9b54\u6cd5\u306e\u30ea\u30ba\u30e0": [
+    "\u3046\u3057\u307f\u3064\u30e2\u30f3\u30b9\u30c8\u30eb\u30aa\n\u30ea\u30f3\u30bc\u3068\u9b54\u6cd5\u306e\u30ea\u30ba\u30e0": [
         "AG3J"
     ],
-    "\u3082\u306e\u3059\u3054\u304f\u8133\u3092\u935b\u3048\u308b\\n\uff15\u5206\u9593\u306e\u9b3c\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
+    "\u3082\u306e\u3059\u3054\u304f\u8133\u3092\u935b\u3048\u308b\n\uff15\u5206\u9593\u306e\u9b3c\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
         "ASRJ"
     ],
-    "\u30df\u30e9\u30af\u30eb\u3061\u3085\u30fc\u3093\u305a\uff01\\n\u30b2\u30fc\u30e0\u3067\u30c1\u30e5\u30fc\u30f3\u30a2\u30c3\u30d7\uff01 \u3060\u30d7\u30f3\uff01": [
+    "\u30df\u30e9\u30af\u30eb\u3061\u3085\u30fc\u3093\u305a\uff01\n\u30b2\u30fc\u30e0\u3067\u30c1\u30e5\u30fc\u30f3\u30a2\u30c3\u30d7\uff01 \u3060\u30d7\u30f3\uff01": [
         "BG7J"
     ],
-    "\u30e9\u30b8\u30a2\u30f3\u30c8\u30d2\u30b9\u30c8\u30ea\u30a2\\n\u30d1\u30fc\u30d5\u30a7\u30af\u30c8\u30af\u30ed\u30ce\u30ed\u30b8\u30fc": [
+    "\u30e9\u30b8\u30a2\u30f3\u30c8\u30d2\u30b9\u30c8\u30ea\u30a2\n\u30d1\u30fc\u30d5\u30a7\u30af\u30c8\u30af\u30ed\u30ce\u30ed\u30b8\u30fc": [
         "BRBJ"
     ],
-    "\u5973\u306e\u5b50\u3068\u5bc6\u5ba4\u306b\u3044\u305f\u3089\\n\u25cb\u25cb\u3057\u3061\u3083\u3046\u304b\u3082\u3057\u308c\u306a\u3044\u3002": [
+    "\u5973\u306e\u5b50\u3068\u5bc6\u5ba4\u306b\u3044\u305f\u3089\n\u25cb\u25cb\u3057\u3061\u3083\u3046\u304b\u3082\u3057\u308c\u306a\u3044\u3002": [
         "AWMJ"
     ],
-    "\u30b9\u30de\u30a4\u30eb\u30d7\u30ea\u30ad\u30e5\u30a2\uff01\\n\u30ec\u30c3\u30c4\u30b4\u30fc\uff01\u30e1\u30eb\u30d8\u30f3\u30ef\u30fc\u30eb\u30c9": [
+    "\u30b9\u30de\u30a4\u30eb\u30d7\u30ea\u30ad\u30e5\u30a2\uff01\n\u30ec\u30c3\u30c4\u30b4\u30fc\uff01\u30e1\u30eb\u30d8\u30f3\u30ef\u30fc\u30eb\u30c9": [
         "APQJ"
     ],
-    "\u521d\u5fc3\u8005\u304b\u3089\u65e5\u672c\u4e00\u307e\u3067\\n\u305d\u308d\u3070\u3093\u30fb\u3042\u3093\u3056\u3093\u30fb\uff8c\uff97\uff6f\uff7c\uff6d\u6697\u7b97": [
+    "\u521d\u5fc3\u8005\u304b\u3089\u65e5\u672c\u4e00\u307e\u3067\n\u305d\u308d\u3070\u3093\u30fb\u3042\u3093\u3056\u3093\u30fb\uff8c\uff97\uff6f\uff7c\uff6d\u6697\u7b97": [
         "AFUJ"
     ],
-    "\u59eb\u30ae\u30e3\u30eb\u2665\u30d1\u30e9\u30c0\u30a4\u30b9\\n\u30e1\u30c1\u30ab\u30ef\uff01\u30a2\u30b2\u76db\u308a\u2191\uff7e\uff9d\uff7e\uff70\uff7c\uff6e\uff9d\uff01": [
+    "\u59eb\u30ae\u30e3\u30eb\u2665\u30d1\u30e9\u30c0\u30a4\u30b9\n\u30e1\u30c1\u30ab\u30ef\uff01\u30a2\u30b2\u76db\u308a\u2191\uff7e\uff9d\uff7e\uff70\uff7c\uff6e\uff9d\uff01": [
         "AHGJ"
     ],
     "\u30eb\u30a4\u30fc\u30b8\u30de\u30f3\u30b7\u30e7\u30f3\uff12": [
@@ -3867,58 +3867,58 @@
     "\u30d6\u30ec\u30a4\u30d6\u30ea\u30fc\u30bb\u30ab\u30f3\u30c9": [
         "BSEJ"
     ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073 \u304d\u304b\u3093\u3057\u3083\\n\u30c8\u30fc\u30de\u30b9\u7de8 \u5927\u4e95\u5ddd\u9435\u9053\u3092\u8d70\u308d\u3046\uff01": [
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073 \u304d\u304b\u3093\u3057\u3083\n\u30c8\u30fc\u30de\u30b9\u7de8 \u5927\u4e95\u5ddd\u9435\u9053\u3092\u8d70\u308d\u3046\uff01": [
         "BTGJ"
     ],
     "\u3068\u3073\u3060\u3059\uff01\u30d1\u30ba\u30eb\u30dc\u30d6\u30eb3D": [
         "ABBJ"
     ],
-    "\u30d0\u30f3\u30c0\u30a4\u30ca\u30e0\u30b3\u30b2\u30fc\u30e0\u30b9PRESENTS\\nJ\u30ec\u30b8\u30a7\u30f3\u30c9\u5217\u4f1d": [
+    "\u30d0\u30f3\u30c0\u30a4\u30ca\u30e0\u30b3\u30b2\u30fc\u30e0\u30b9PRESENTS\nJ\u30ec\u30b8\u30a7\u30f3\u30c9\u5217\u4f1d": [
         "BNGJ"
     ],
-    "\u904a\u3093\u3067\u5c06\u68cb\u304c\u5f37\u304f\u306a\u308b\uff01\\n\u9280\u661f\u5c06\u68cbDX": [
+    "\u904a\u3093\u3067\u5c06\u68cb\u304c\u5f37\u304f\u306a\u308b\uff01\n\u9280\u661f\u5c06\u68cbDX": [
         "BSGJ"
     ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u8fd1\u6c5f\u9244\u9053\u7de8": [
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u8fd1\u6c5f\u9244\u9053\u7de8": [
         "ATJJ"
     ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u53e1\u5c71\u96fb\u8eca\u7de8": [
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u53e1\u5c71\u96fb\u8eca\u7de8": [
         "BEDJ"
     ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u4f1a\u6d25\u9244\u9053\u7de8": [
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u4f1a\u6d25\u9244\u9053\u7de8": [
         "BTXJ"
     ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u9577\u826f\u5ddd\u9244\u9053\u7de8": [
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u9577\u826f\u5ddd\u9244\u9053\u7de8": [
         "ARJJ"
     ],
-    "\u304a\u3055\u308f\u308a\u63a2\u5075\u3000\u5c0f\u6ca2\u91cc\u5948\\n\u306a\u3081\u3053\u30ea\u30ba\u30e0": [
+    "\u304a\u3055\u308f\u308a\u63a2\u5075\u3000\u5c0f\u6ca2\u91cc\u5948\n\u306a\u3081\u3053\u30ea\u30ba\u30e0": [
         "BSLJ"
     ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u3086\u3044\u30ec\u30fc\u30eb\u7de8": [
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u3086\u3044\u30ec\u30fc\u30eb\u7de8": [
         "BTYJ"
     ],
-    "\u30dd\u30b1\u30c3\u30c8\u30b5\u30c3\u30ab\u30fc\u30ea\u30fc\u30b0\\n\u30ab\u30eb\u30c1\u30e7\u30d3\u30c3\u30c8": [
+    "\u30dd\u30b1\u30c3\u30c8\u30b5\u30c3\u30ab\u30fc\u30ea\u30fc\u30b0\n\u30ab\u30eb\u30c1\u30e7\u30d3\u30c3\u30c8": [
         "AHBJ"
     ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u9e7f\u5cf6\u81e8\u6d77\u9244\u9053\u7de8": [
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u9e7f\u5cf6\u81e8\u6d77\u9244\u9053\u7de8": [
         "ARKJ"
     ],
-    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\\n\u4e0a\u6bdb\u96fb\u6c17\u9244\u9053\u7de8": [
+    "\u9244\u9053\u306b\u3063\u307d\u3093\uff01\u8def\u7dda\u305f\u3073\n\u4e0a\u6bdb\u96fb\u6c17\u9244\u9053\u7de8": [
         "BTJJ"
     ],
-    "\u84bc\u304d\u96f7\u9706\u3000\u30ac\u30f3\u30f4\u30a9\u30eb\u30c8\\n\u30b9\u30c8\u30e9\u30a4\u30ab\u30fc\u30d1\u30c3\u30af": [
+    "\u84bc\u304d\u96f7\u9706\u3000\u30ac\u30f3\u30f4\u30a9\u30eb\u30c8\n\u30b9\u30c8\u30e9\u30a4\u30ab\u30fc\u30d1\u30c3\u30af": [
         "BG8J"
     ],
-    "\u30a2\u30f3\u30d1\u30f3\u30de\u30f3\u3068\u30bf\u30c3\u30c1\u3067\\n\u308f\u304f\u308f\u304f\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
+    "\u30a2\u30f3\u30d1\u30f3\u30de\u30f3\u3068\u30bf\u30c3\u30c1\u3067\n\u308f\u304f\u308f\u304f\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
         "BWTJ"
     ],
-    "\u50d5\u306e\u30d2\u30fc\u30ed\u30fc\u30a2\u30ab\u30c7\u30df\u30a2\\n\u30d0\u30c8\u30eb\u30fb\u30d5\u30a9\u30fc\u30fb\u30aa\u30fc\u30eb": [
+    "\u50d5\u306e\u30d2\u30fc\u30ed\u30fc\u30a2\u30ab\u30c7\u30df\u30a2\n\u30d0\u30c8\u30eb\u30fb\u30d5\u30a9\u30fc\u30fb\u30aa\u30fc\u30eb": [
         "BHAJ"
     ],
-    "\u30d6\u30ec\u30a4\u30d6\u30ea\u30fc\u30c7\u30d5\u30a9\u30eb\u30c8\\n\u30d5\u30a9\u30fc\u30b6\u30fb\u30b7\u30fc\u30af\u30a6\u30a7\u30eb": [
+    "\u30d6\u30ec\u30a4\u30d6\u30ea\u30fc\u30c7\u30d5\u30a9\u30eb\u30c8\n\u30d5\u30a9\u30fc\u30b6\u30fb\u30b7\u30fc\u30af\u30a6\u30a7\u30eb": [
         "BTRJ"
     ],
-    "\u8b0e\u89e3\u304d\u30d0\u30c8\u30eb\uff34\uff2f\uff32\uff25\uff01\\n\u4f1d\u8aac\u306e\u9b54\u5bae\u3092\u5fa9\u6d3b\u3055\u305b\u3088\uff01": [
+    "\u8b0e\u89e3\u304d\u30d0\u30c8\u30eb\uff34\uff2f\uff32\uff25\uff01\n\u4f1d\u8aac\u306e\u9b54\u5bae\u3092\u5fa9\u6d3b\u3055\u305b\u3088\uff01": [
         "BREJ"
     ],
     "\u30d6\u30ec\u30a4\u30d6\u30ea\u30fc\u30c7\u30d5\u30a9\u30eb\u30c8": [
@@ -3942,28 +3942,28 @@
     "\u30c9\u30e9\u30a4\u30d0\u30fc\uff1a\u30ec\u30cd\u30b2\u30a4\u30c9\uff13D": [
         "ADRJ"
     ],
-    "\u7a7a\u9593\u3055\u304c\u3057\u3082\u306e\u7cfb\u8133\u529b\u958b\u767a\\n\uff13\uff24\u8133\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
+    "\u7a7a\u9593\u3055\u304c\u3057\u3082\u306e\u7cfb\u8133\u529b\u958b\u767a\n\uff13\uff24\u8133\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0": [
         "AKTJ"
     ],
-    "\u5927\u6226\u7565\u3000\u5927\u6771\u4e9c\u8208\u4ea1\u53f2\uff24\uff38\\n\uff5e\u7b2c\u4e8c\u6b21\u4e16\u754c\u5927\u6226\uff5e": [
+    "\u5927\u6226\u7565\u3000\u5927\u6771\u4e9c\u8208\u4ea1\u53f2\uff24\uff38\n\uff5e\u7b2c\u4e8c\u6b21\u4e16\u754c\u5927\u6226\uff5e": [
         "BFEJ"
     ],
-    "\u30cf\u30ed\u30fc\u30ad\u30c6\u30a3\u3068\u3044\u3063\u3057\u3087\uff01\\n\u30d6\u30ed\u30c3\u30af\u30af\u30e9\u30c3\u30b7\u30e5\uff3a": [
+    "\u30cf\u30ed\u30fc\u30ad\u30c6\u30a3\u3068\u3044\u3063\u3057\u3087\uff01\n\u30d6\u30ed\u30c3\u30af\u30af\u30e9\u30c3\u30b7\u30e5\uff3a": [
         "AHZJ"
     ],
-    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u3000\u5927\u6d77\u7269\u8a9e\uff12\\n\uff5e\u30d1\u30c1\u30d7\u30ed\u98a8\u96f2\u9332\u30fb\u82b1\uff5e": [
+    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u3000\u5927\u6d77\u7269\u8a9e\uff12\n\uff5e\u30d1\u30c1\u30d7\u30ed\u98a8\u96f2\u9332\u30fb\u82b1\uff5e": [
         "AU3J"
     ],
-    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u3000\u5927\u6d77\u7269\u8a9e\uff12\\n\uff37\uff49\uff54\uff48\u3000\u30a2\u30b0\u30cd\u30b9\u30fb\u30e9\u30e0": [
+    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u3000\u5927\u6d77\u7269\u8a9e\uff12\n\uff37\uff49\uff54\uff48\u3000\u30a2\u30b0\u30cd\u30b9\u30fb\u30e9\u30e0": [
         "AU2J"
     ],
-    "\u30c7\u30a3\u30ba\u30cb\u30fc\u30a4\u30f3\u30d5\u30a3\u30cb\u30c6\u30a3\\n\u30c8\u30a4\u30fb\u30dc\u30c3\u30af\u30b9\u30fb\u30c1\u30e3\u30ec\u30f3\u30b8": [
+    "\u30c7\u30a3\u30ba\u30cb\u30fc\u30a4\u30f3\u30d5\u30a3\u30cb\u30c6\u30a3\n\u30c8\u30a4\u30fb\u30dc\u30c3\u30af\u30b9\u30fb\u30c1\u30e3\u30ec\u30f3\u30b8": [
         "ADYJ"
     ],
-    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30eb\u30d2\u30fc\u30ed\u30fc\u30ba\\n\u30a2\u30eb\u30c6\u30a3\u30e1\u30c3\u30c8\u30df\u30c3\u30b7\u30e7\u30f3\uff38": [
+    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30eb\u30d2\u30fc\u30ed\u30fc\u30ba\n\u30a2\u30eb\u30c6\u30a3\u30e1\u30c3\u30c8\u30df\u30c3\u30b7\u30e7\u30f3\uff38": [
         "BD9J"
     ],
-    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30eb\u30d2\u30fc\u30ed\u30fc\u30ba\\n\u30a2\u30eb\u30c6\u30a3\u30e1\u30c3\u30c8\u30df\u30c3\u30b7\u30e7\u30f3\uff12": [
+    "\u30c9\u30e9\u30b4\u30f3\u30dc\u30fc\u30eb\u30d2\u30fc\u30ed\u30fc\u30ba\n\u30a2\u30eb\u30c6\u30a3\u30e1\u30c3\u30c8\u30df\u30c3\u30b7\u30e7\u30f3\uff12": [
         "BDBJ"
     ],
     "\u5263\u3068\u9b54\u6cd5\u3068\u5b66\u5712\u30e2\u30ce\u3002\uff13\uff24": [
@@ -3981,25 +3981,25 @@
     "\u30b9\u30fc\u30d1\u30fc\u30ed\u30dc\u30c3\u30c8\u5927\u6226\uff22\uff38": [
         "BSRJ"
     ],
-    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3\uff11\u30fb\uff12\u30fb\uff13!!\\n\u5186\u5802\u5b88\u4f1d\u8aac": [
+    "\u30a4\u30ca\u30ba\u30de\u30a4\u30ec\u30d6\u30f3\uff11\u30fb\uff12\u30fb\uff13!!\n\u5186\u5802\u5b88\u4f1d\u8aac": [
         "AETJ"
     ],
-    "\uff27\uff4f\uff01\u30d7\u30ea\u30f3\u30bb\u30b9\u30d7\u30ea\u30ad\u30e5\u30a2\\n\u30b7\u30e5\u30ac\u30fc\u738b\u56fd\u30686\u4eba\u306e\u30d7\u30ea\u30f3\u30bb\u30b9\uff01": [
+    "\uff27\uff4f\uff01\u30d7\u30ea\u30f3\u30bb\u30b9\u30d7\u30ea\u30ad\u30e5\u30a2\n\u30b7\u30e5\u30ac\u30fc\u738b\u56fd\u30686\u4eba\u306e\u30d7\u30ea\u30f3\u30bb\u30b9\uff01": [
         "BG5J"
     ],
-    "\u30c8\u30fc\u30de\u30b9\u3068\u3042\u305d\u3093\u3067\u304a\u307c\u3048\u308b\\n\u3053\u3068\u3070\u3068\u304b\u305a\u3068ABC": [
+    "\u30c8\u30fc\u30de\u30b9\u3068\u3042\u305d\u3093\u3067\u304a\u307c\u3048\u308b\n\u3053\u3068\u3070\u3068\u304b\u305a\u3068ABC": [
         "BTFJ"
     ],
-    "\u7363\u96fb\u6226\u968a\u30ad\u30e7\u30a6\u30ea\u30e5\u30a6\u30b8\u30e3\u30fc\\n\u30b2\u30fc\u30e0\u3067\u30ac\u30d6\u30ea\u30f3\u30c1\u30e7\uff01\uff01": [
+    "\u7363\u96fb\u6226\u968a\u30ad\u30e7\u30a6\u30ea\u30e5\u30a6\u30b8\u30e3\u30fc\n\u30b2\u30fc\u30e0\u3067\u30ac\u30d6\u30ea\u30f3\u30c1\u30e7\uff01\uff01": [
         "AAKJ"
     ],
-    "\u30ac\u30fc\u30eb\u30ba\u30d5\u30a1\u30c3\u30b7\u30e7\u30f3\uff13\uff24\u2606\\n\u3081\u3056\u305b\uff01\u30c8\u30c3\u30d7\u30b9\u30bf\u30a4\u30ea\u30b9\u30c8": [
+    "\u30ac\u30fc\u30eb\u30ba\u30d5\u30a1\u30c3\u30b7\u30e7\u30f3\uff13\uff24\u2606\n\u3081\u3056\u305b\uff01\u30c8\u30c3\u30d7\u30b9\u30bf\u30a4\u30ea\u30b9\u30c8": [
         "AGUJ"
     ],
-    "\u304b\u308f\u3044\u3044\u30da\u30c3\u30c8\u3068\u304f\u3089\u305d\u3046\uff01\\n\u308f\u3093\u30cb\u30e3\u30f3\uff06\u30df\u30cb\u30df\u30cb\u30a2\u30cb\u30de\u30eb": [
+    "\u304b\u308f\u3044\u3044\u30da\u30c3\u30c8\u3068\u304f\u3089\u305d\u3046\uff01\n\u308f\u3093\u30cb\u30e3\u30f3\uff06\u30df\u30cb\u30df\u30cb\u30a2\u30cb\u30de\u30eb": [
         "BHSJ"
     ],
-    "\u304b\u308f\u3044\u3044\u30da\u30c3\u30c8\u3068\u304f\u3089\u305d\u3046\uff01\\n\u308f\u3093\u30cb\u30e3\u30f3\uff06\u30a2\u30a4\u30c9\u30eb\u30a2\u30cb\u30de\u30eb": [
+    "\u304b\u308f\u3044\u3044\u30da\u30c3\u30c8\u3068\u304f\u3089\u305d\u3046\uff01\n\u308f\u3093\u30cb\u30e3\u30f3\uff06\u30a2\u30a4\u30c9\u30eb\u30a2\u30cb\u30de\u30eb": [
         "BWAJ"
     ],
     "\u30d5\u30a1\u30a4\u30a2\u30fc\u30a8\u30e0\u30d6\u30ec\u30e0\u3000\u899a\u9192": [
@@ -4014,10 +4014,10 @@
     "\u771f\u30fb\u5973\u795e\u8ee2\u751f\u2163\u3000\uff26\uff29\uff2e\uff21\uff2c": [
         "BG4J"
     ],
-    "\u30cf\u30d4\u30cd\u30b9\u30c1\u30e3\u30fc\u30b8\u30d7\u30ea\u30ad\u30e5\u30a2\uff01\\n\u304b\u308f\u30eb\u30f3\u2606\u30b3\u30ec\u30af\u30b7\u30e7\u30f3": [
+    "\u30cf\u30d4\u30cd\u30b9\u30c1\u30e3\u30fc\u30b8\u30d7\u30ea\u30ad\u30e5\u30a2\uff01\n\u304b\u308f\u30eb\u30f3\u2606\u30b3\u30ec\u30af\u30b7\u30e7\u30f3": [
         "BHCJ"
     ],
-    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u30d7\u30ec\u30df\u30a2\u30e0\u6d77\u7269\u8a9e\\n\uff5e\u5922\u898b\u308b\u4e59\u5973\u3068\u30d1\u30c1\u30f3\u30b3\u738b\u6c7a\u5b9a\u6226\uff5e": [
+    "\u30d1\u30c1\u30d1\u30e9\uff13\uff24\u30d7\u30ec\u30df\u30a2\u30e0\u6d77\u7269\u8a9e\n\uff5e\u5922\u898b\u308b\u4e59\u5973\u3068\u30d1\u30c1\u30f3\u30b3\u738b\u6c7a\u5b9a\u6226\uff5e": [
         "AUMJ"
     ],
     "\u6226\u56fd\u7121\u53cc\u30af\u30ed\u30cb\u30af\u30eb\u3000\u30bb\u30ab\u30f3\u30c9": [
@@ -4029,34 +4029,34 @@
     "\u30c8\u30e2\u30c0\u30c1\u30b3\u30ec\u30af\u30b7\u30e7\u30f3\u3000\u65b0\u751f\u6d3b": [
         "EC6J"
     ],
-    "\u30e2\u30c7\u30eb\u2606\u304a\u3057\u3083\u308c\u30aa\u30fc\u30c7\u30a3\u30b7\u30e7\u30f3\\n\u30d7\u30e9\u30c1\u30ca": [
+    "\u30e2\u30c7\u30eb\u2606\u304a\u3057\u3083\u308c\u30aa\u30fc\u30c7\u30a3\u30b7\u30e7\u30f3\n\u30d7\u30e9\u30c1\u30ca": [
         "AN9J"
     ],
-    "\u30aa\u30b7\u30e3\u30ec\u3067\u304b\u308f\u3044\u3044\u5b50\u72ac\u3068\u904a\u307c\uff01\\n\uff0d\u6d77\u7de8\uff0d": [
+    "\u30aa\u30b7\u30e3\u30ec\u3067\u304b\u308f\u3044\u3044\u5b50\u72ac\u3068\u904a\u307c\uff01\n\uff0d\u6d77\u7de8\uff0d": [
         "APIJ"
     ],
-    "\u30aa\u30b7\u30e3\u30ec\u3067\u304b\u308f\u3044\u3044\u5b50\u72ac\u3068\u904a\u307c\uff01\\n\uff0d\u8857\u7de8\uff0d": [
+    "\u30aa\u30b7\u30e3\u30ec\u3067\u304b\u308f\u3044\u3044\u5b50\u72ac\u3068\u904a\u307c\uff01\n\uff0d\u8857\u7de8\uff0d": [
         "APOJ"
     ],
-    "\u30e2\u30c7\u30eb\u2606\u304a\u3057\u3083\u308c\u30aa\u30fc\u30c7\u30a3\u30b7\u30e7\u30f3\\n\u30c9\u30ea\u30fc\u30e0\u30ac\u30fc\u30eb": [
+    "\u30e2\u30c7\u30eb\u2606\u304a\u3057\u3083\u308c\u30aa\u30fc\u30c7\u30a3\u30b7\u30e7\u30f3\n\u30c9\u30ea\u30fc\u30e0\u30ac\u30fc\u30eb": [
         "AYCJ"
     ],
-    "\u30cf\u30ed\u30fc\u30ad\u30c6\u30a3\u3068\u307e\u307b\u3046\u306e\u30a8\u30d7\u30ed\u30f3\\n\u30ea\u30ba\u30e0\u30af\u30c3\u30ad\u30f3\u30b0\u266a": [
+    "\u30cf\u30ed\u30fc\u30ad\u30c6\u30a3\u3068\u307e\u307b\u3046\u306e\u30a8\u30d7\u30ed\u30f3\n\u30ea\u30ba\u30e0\u30af\u30c3\u30ad\u30f3\u30b0\u266a": [
         "BHKJ"
     ],
-    "\uff2d\uff2f\uff25\uff2d\uff2f\uff25\uff24\uff21\uff29\uff33\uff25\uff2e\uff33\uff2f\uff35\\n\uff27\uff25\uff2e\uff24\uff21\uff29\uff22\uff21\uff2e\uff13\uff24": [
+    "\uff2d\uff2f\uff25\uff2d\uff2f\uff25\uff24\uff21\uff29\uff33\uff25\uff2e\uff33\uff2f\uff35\n\uff27\uff25\uff2e\uff24\uff21\uff29\uff22\uff21\uff2e\uff13\uff24": [
         "AMAJ"
     ],
-    "\u306d\u3089\u3063\u3066\uff01\u3068\u3070\u3057\u3066\uff01\u30ea\u30e9\u30c3\u30af\u30de\\n\u3050\u3089\u3050\u3089\u30b9\u30a4\u30fc\u30c4\u30bf\u30ef\u30fc": [
+    "\u306d\u3089\u3063\u3066\uff01\u3068\u3070\u3057\u3066\uff01\u30ea\u30e9\u30c3\u30af\u30de\n\u3050\u3089\u3050\u3089\u30b9\u30a4\u30fc\u30c4\u30bf\u30ef\u30fc": [
         "ARLJ"
     ],
-    "\u30c9\u30e9\u3048\u3082\u3093\u3000\u306e\u3073\u592a\u306e\u5b87\u5b99\u82f1\u96c4\u8a18\\n\uff08\u30b9\u30da\u30fc\u30b9\u30d2\u30fc\u30ed\u30fc\u30ba\uff09": [
+    "\u30c9\u30e9\u3048\u3082\u3093\u3000\u306e\u3073\u592a\u306e\u5b87\u5b99\u82f1\u96c4\u8a18\n\uff08\u30b9\u30da\u30fc\u30b9\u30d2\u30fc\u30ed\u30fc\u30ba\uff09": [
         "BS5J"
     ],
-    "\u30c7\u30a3\u30ba\u30cb\u30fc\u3000\u30de\u30b8\u30c3\u30af\u30ad\u30e3\u30c3\u30b9\u30eb\\n\u30de\u30a4\u30fb\u30cf\u30c3\u30d4\u30fc\u30fb\u30e9\u30a4\u30d5\uff12": [
+    "\u30c7\u30a3\u30ba\u30cb\u30fc\u3000\u30de\u30b8\u30c3\u30af\u30ad\u30e3\u30c3\u30b9\u30eb\n\u30de\u30a4\u30fb\u30cf\u30c3\u30d4\u30fc\u30fb\u30e9\u30a4\u30d5\uff12": [
         "BD2J"
     ],
-    "\u305f\u307e\u3054\u3063\u3061\u306e\u30d7\u30c1\u30d7\u30c1\u304a\u307f\u305b\u3063\u3061\\n\uff5e\u306b\u3093\u304d\u306e\u304a\u307f\u305b\u3042\u3064\u3081\u307e\u3057\u305f\uff5e": [
+    "\u305f\u307e\u3054\u3063\u3061\u306e\u30d7\u30c1\u30d7\u30c1\u304a\u307f\u305b\u3063\u3061\n\uff5e\u306b\u3093\u304d\u306e\u304a\u307f\u305b\u3042\u3064\u3081\u307e\u3057\u305f\uff5e": [
         "BT4J"
     ],
     "\u3073\u3063\u304f\u308a\uff01\u3068\u3073\u3060\u3059\uff01\u9b54\u6cd5\u306e\u30da\u30f3": [
@@ -4071,16 +4071,16 @@
     "\u30c6\u30f3\u30ab\u30a4\u30ca\u30a4\u30c8\u3000\u30d6\u30ec\u30a4\u30d6\u30d0\u30c8\u30eb": [
         "BTKJ"
     ],
-    "\u30d7\u30ea\u30c6\u30a3\u30fc\u30ea\u30ba\u30e0\u30ec\u30a4\u30f3\u30dc\u30fc\u30e9\u30a4\u30d6\\n\u304d\u3089\u304d\u3089\u30de\u30a4\u2606\u30c7\u30b6\u30a4\u30f3": [
+    "\u30d7\u30ea\u30c6\u30a3\u30fc\u30ea\u30ba\u30e0\u30ec\u30a4\u30f3\u30dc\u30fc\u30e9\u30a4\u30d6\n\u304d\u3089\u304d\u3089\u30de\u30a4\u2606\u30c7\u30b6\u30a4\u30f3": [
         "BP2J"
     ],
-    "\u30c1\u30e7\u30b3\u72ac\u306e\u3061\u3087\u3053\u3063\u3068\u4e0d\u601d\u8b70\u306a\u7269\u8a9e\\n\u30b7\u30e7\u30b3\u30e9\u59eb\u3068\u9b54\u6cd5\u306e\u30ec\u30b7\u30d4": [
+    "\u30c1\u30e7\u30b3\u72ac\u306e\u3061\u3087\u3053\u3063\u3068\u4e0d\u601d\u8b70\u306a\u7269\u8a9e\n\u30b7\u30e7\u30b3\u30e9\u59eb\u3068\u9b54\u6cd5\u306e\u30ec\u30b7\u30d4": [
         "BCHJ"
     ],
-    "\u305d\u308d\u3070\u3093\u30fb\u3042\u3093\u3056\u3093\u30fb\uff8c\uff97\uff6f\uff7c\uff6d\u6697\u7b97\\n\u5b8c\u5168\u7248": [
+    "\u305d\u308d\u3070\u3093\u30fb\u3042\u3093\u3056\u3093\u30fb\uff8c\uff97\uff6f\uff7c\uff6d\u6697\u7b97\n\u5b8c\u5168\u7248": [
         "BSAJ"
     ],
-    "\u30b9\u30e9\u30a4\u30e0\u3082\u308a\u3082\u308a\u30c9\u30e9\u30b4\u30f3\u30af\u30a8\u30b9\u30c8\uff13\\n\u5927\u6d77\u8cca\u3068\u3057\u3063\u307d\u56e3": [
+    "\u30b9\u30e9\u30a4\u30e0\u3082\u308a\u3082\u308a\u30c9\u30e9\u30b4\u30f3\u30af\u30a8\u30b9\u30c8\uff13\n\u5927\u6d77\u8cca\u3068\u3057\u3063\u307d\u56e3": [
         "AMRJ"
     ]
 }


### PR DESCRIPTION
Applies to #14 

This adds a 3DS endpoint in RiiTag. This should handle regions based on the selected Region Cover type, and use that to pass along the correct game ID for cover rendering.

This also implements the small bug fix from #41 which I closed when I published these changes.

Credit to @larsenv for the 3ds.json file