### PR TITLE
Update dd-trace (0.31.0 -> 0.33.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "body-parser": "^1.19.0",
     "canvas": "^2.6.1",
     "connect-datadog": "^0.0.9",
-    "dd-trace": "^0.31.0",
+    "dd-trace": "^0.33.1",
     "express": "^4.17.1",
     "express-session": "^1.17.0",
     "hot-shots": "^8.3.0",


### PR DESCRIPTION
Yesterday, May 6th, a vulnerability advisory went out for the package `hosted-git-info`, which is a dependency of dd-trace. dd-trace version 0.33.1 relies on an updated version of the previous package that has this vulnerability patched.

Vulnerability: Moderate - Regular Expression Denial of Service
More info can be found at https://www.npmjs.com/advisories/1677.